### PR TITLE
opt: CI-friendly test optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "scrape:discover": "node scripts/discover-top-companies.mjs && node scripts/scraper/run-scraper.mjs",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\" \"data/**/*.json\"",
     "test": "vitest",
+    "test:ci:unit": "vitest run --reporter dot",
+    "test:ci:e2e": "playwright test",
+    "test:ci": "npm ci --silent && npm run test:ci:unit && npm run test:ci:e2e",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { cpus } from 'os';
+const CPU_CORES = cpus().length;
+const CI = Boolean(process.env.CI);
 
 /**
  * Playwright configuration for end-to-end testing of GlobalOfficeFinder
@@ -7,8 +10,8 @@ export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.spec.ts',
   
-  // Run tests in 3 worker processes in parallel
-  workers: 3,
+  // Run tests in parallel with a CI-safe cap
+  workers: CI ? 2 : Math.min(3, CPU_CORES),
   
   // Number of retries for failed tests
   retries: 1,
@@ -36,9 +39,9 @@ export default defineConfig({
   // Use baseURL for relative navigation
   use: {
     baseURL: 'http://localhost:5173',
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    trace: CI ? 'off' : 'on-first-retry',
+    screenshot: CI ? 'off' : 'only-on-failure',
+    video: CI ? 'off' : 'retain-on-failure',
   },
 
   // Configure web server

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "vitest/config";
+import { cpus } from "os";
+const CPU_CORES = cpus().length;
+const IS_CI = Boolean(process.env.CI);
 import react from "@vitejs/plugin-react";
+
+const CPU_CORES = cpus().length;
+const IS_CI = Boolean(process.env.CI);
+const MAX_WORKERS = IS_CI ? Math.max(1, Math.min(2, CPU_CORES)) : Math.max(1, Math.min(4, CPU_CORES));
 
 export default defineConfig({
   plugins: [react()],
@@ -8,6 +15,7 @@ export default defineConfig({
     environment: "happy-dom",
     setupFiles: "./vitest.setup.ts",
     exclude: ["**/node_modules/**", "**/e2e/**", "**/dist/**"],
+    maxWorkers: MAX_WORKERS,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
CI-friendly tweaks to test infra: limit workers in Vitest and Playwright, add test:ci scripts, and CI-aware settings.