### PR TITLE
docs(changelog): note CodeQL URL parsing fix (PR-50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Unreleased
+- Fix CodeQL: robust URL parsing tests (PR-50)


### PR DESCRIPTION
Add changelog entry documenting robust URL parsing fixes for CodeQL alerts in scraper-utils tests. This PR introduces PR-50 as a separate track for the change.