### PR TITLE
feat: gate public offices by approval; queue-only scraper output

### DIFF
--- a/__tests__/utils/homePublishedOffices.test.ts
+++ b/__tests__/utils/homePublishedOffices.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { Company, Office } from "../../src/types";
+import { getFilteredHomeData } from "../../src/utils/filters";
+import { filterPublishedOffices } from "../../src/utils/officeVisibility";
+
+/** Mirrors HomePage: only published offices feed the home filters and map. */
+describe("home listing respects office approval", () => {
+  const companies: Company[] = [
+    {
+      id: "solo",
+      name: "Solo Co",
+      website: "https://solo.example",
+      industry: "Technology",
+      description: "d",
+      logo: "",
+    },
+  ];
+
+  const offices: Office[] = [
+    {
+      id: "solo-us",
+      companyId: "solo",
+      country: "United States",
+      countryCode: "US",
+      region: "Americas",
+      city: "Austin",
+      address: "1 Rd",
+      postalCode: "78701",
+      officeType: "Headquarters",
+      approved: false,
+      latitude: 30,
+      longitude: -97,
+    },
+  ];
+
+  it("excludes unapproved offices when data is pre-filtered like HomePage", () => {
+    const published = filterPublishedOffices(offices);
+    const result = getFilteredHomeData(companies, published, {
+      region: "",
+      country: "",
+      industry: "",
+      officeType: "",
+      hasHq: false,
+      hasContactUrl: false,
+    });
+    expect(result.filteredCompanies).toHaveLength(0);
+    expect(result.mapOffices).toHaveLength(0);
+  });
+});

--- a/__tests__/utils/officeVisibility.test.ts
+++ b/__tests__/utils/officeVisibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { Office } from "../../src/types";
+import { filterPublishedOffices, isPublishedOffice } from "../../src/utils/officeVisibility";
+
+const base: Office = {
+  id: "x",
+  companyId: "c",
+  country: "United States",
+  countryCode: "US",
+  region: "Americas",
+  city: "NYC",
+  address: "1 St",
+  postalCode: "10001",
+  officeType: "Headquarters",
+};
+
+describe("isPublishedOffice", () => {
+  it("treats missing approved as published", () => {
+    expect(isPublishedOffice(base)).toBe(true);
+  });
+
+  it("treats approved true as published", () => {
+    expect(isPublishedOffice({ ...base, approved: true })).toBe(true);
+  });
+
+  it("treats approved false as unpublished", () => {
+    expect(isPublishedOffice({ ...base, approved: false })).toBe(false);
+  });
+});
+
+describe("filterPublishedOffices", () => {
+  it("drops only offices explicitly marked not approved", () => {
+    const list: Office[] = [base, { ...base, id: "y", approved: false }];
+    expect(filterPublishedOffices(list)).toEqual([base]);
+  });
+});

--- a/data/schema/offices.schema.json
+++ b/data/schema/offices.schema.json
@@ -75,6 +75,10 @@
         "type": "string",
         "pattern": "^(https?://.*)?$",
         "description": "Optional contact URL"
+      },
+      "approved": {
+        "type": "boolean",
+        "description": "If false, office is hidden on the public site until set to true"
       }
     }
   }

--- a/scripts/scraper/promote-accepted.mjs
+++ b/scripts/scraper/promote-accepted.mjs
@@ -62,7 +62,7 @@ function main() {
     if (officeKeys.has(key)) continue;
     // ensure id
     if (!e.id) e.id = makeOfficeId(offices.concat(toAdd), e.companyId, e.countryCode, e.city);
-    toAdd.push(e);
+    toAdd.push({ ...e, approved: true });
     officeKeys.add(key);
   }
 

--- a/scripts/scraper/review-queue-cli.mjs
+++ b/scripts/scraper/review-queue-cli.mjs
@@ -273,7 +273,7 @@ async function main() {
     };
     const id = makeOfficeId(existingOffices.concat(toAdd), office.companyId, office.countryCode, office.city);
     existingKeys.add(dedupeKey);
-    toAdd.push({ id, ...office });
+    toAdd.push({ id, ...office, approved: true });
   }
 
   if (toAdd.length === 0) {

--- a/scripts/scraper/run-scraper.mjs
+++ b/scripts/scraper/run-scraper.mjs
@@ -987,6 +987,8 @@ async function main() {
   // Stage 3+4+5: extract, normalize, geocode, dedupe, quality controls
   const acceptedCompanies = [];
   const acceptedOffices = [];
+  /** High-confidence discoveries held for humans in review-queue.json (not written to offices.json). */
+  let officesQueuedForManualReview = 0;
   const companyIdRemap = new Map();
 
   const mergedCompanies = [...existingCompanies];
@@ -1138,18 +1140,16 @@ async function main() {
 
       normalizedOffice.id = makeOfficeId(mergedOffices, normalizedOffice.companyId, normalizedOffice.countryCode, normalizedOffice.city);
       officeKeys.add(dedupeKey);
-      mergedOffices.push(normalizedOffice);
-      acceptedOffices.push({
-        ...normalizedOffice,
-        source: {
-          sourceId: source.id,
-          sourceUrl: source.sourceUrl,
-          scrapedAt: nowIso(),
-          confidence: confidence.level,
-          confidenceScore: confidence.score,
-          officialSourceMatch,
-          geocodeCertainty,
-        },
+      officesQueuedForManualReview += 1;
+      reviewQueue.push({
+        type: "office",
+        sourceId: source.id,
+        sourceUrl: source.sourceUrl,
+        office: normalizedOffice,
+        reason: "awaiting manual approval before publication",
+        confidence: confidence.level,
+        confidenceScore: confidence.score,
+        queuedAt: nowIso(),
       });
     }
   }
@@ -1167,6 +1167,7 @@ async function main() {
       collectedPages: collectedPageData.length,
       acceptedCompanies: acceptedCompanies.length,
       acceptedOffices: acceptedOffices.length,
+      officesQueuedForManualReview,
       reviewQueueItems: reviewQueue.length,
       skippedSources: skippedSources.length,
     },
@@ -1221,6 +1222,7 @@ async function main() {
         latitude: typeof raw.latitude === 'number' ? raw.latitude : undefined,
         longitude: typeof raw.longitude === 'number' ? raw.longitude : undefined,
         contactUrl: sanitizeUrl(raw.contactUrl) || sanitizeUrl(item.sourceUrl) || undefined,
+        approved: true,
       };
 
       // geocode if coords missing
@@ -1295,7 +1297,7 @@ async function main() {
 
   writeJson(RUN_REPORT_PATH, runReport);
 
-  console.log(`[scraper] discovered=${discovered.length} acceptedCompanies=${acceptedCompanies.length} acceptedOffices=${acceptedOffices.length} reviewQueue=${reviewQueue.length} dryRun=${DRY_RUN}`);
+  console.log(`[scraper] discovered=${discovered.length} acceptedCompanies=${acceptedCompanies.length} acceptedOffices=${acceptedOffices.length} officesQueuedForManualReview=${officesQueuedForManualReview} reviewQueue=${reviewQueue.length} dryRun=${DRY_RUN}`);
 }
 
 // Guard main execution to allow importing this module safely for tests

--- a/src/App.css
+++ b/src/App.css
@@ -381,6 +381,22 @@
   opacity: .55;
   pointer-events: none;
 }
+.queue-section {
+  margin-bottom: 2rem;
+}
+.queue-section h2 {
+  margin-bottom: 0.35rem;
+  font-size: 1.15rem;
+}
+.held-back-catalog-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  color: #1f2937;
+}
+.queue-section-rejected {
+  border-left: 3px solid #fecaca;
+  padding-left: 1rem;
+}
 
 /* ── Error / 404 ─────────────────────────────────────────── */
 .page-error { text-align: center; padding: 4rem 1rem; }

--- a/src/pages/CompanyPage.tsx
+++ b/src/pages/CompanyPage.tsx
@@ -6,9 +6,10 @@ import type { Company, Office } from "../types";
 import OfficeCard from "../components/OfficeCard";
 import { MapView } from "../components/MapView";
 import { sanitizeUrl } from "../utils/data";
+import { filterPublishedOffices } from "../utils/officeVisibility";
 
 const allCompanies = companies as Company[];
-const allOffices = offices as Office[];
+const publishedOffices = filterPublishedOffices(offices as Office[]);
 const DEFAULT_WORLD_CENTER: [number, number] = [20, 0]; // Leaflet [lat, lng] tuple: 20°N latitude, 0° longitude
 const SINGLE_OFFICE_ZOOM = 10;
 const MULTI_OFFICE_ZOOM = 3;
@@ -51,7 +52,7 @@ export default function CompanyPage() {
     );
   }
 
-  const companyOffices = allOffices.filter((o) => o.companyId === company.id);
+  const companyOffices = publishedOffices.filter((o) => o.companyId === company.id);
   const mapOffices = companyOffices.filter(
     (office): office is CoordinateOffice =>
       office.latitude !== undefined && office.longitude !== undefined
@@ -143,6 +144,12 @@ const mapCenter = getAverageCoordinates(mapOffices);
 
       <section className="offices-section">
         <h2>Office Locations</h2>
+        {companyOffices.length === 0 ? (
+          <p className="no-results">
+            No published office locations are listed for this company yet. Locations may still be
+            under editorial review.
+          </p>
+        ) : (
         <div className="company-offices-layout">
           <div className="company-offices-list">
             {[...grouped.entries()].sort().map(([region, byCountry]) => (
@@ -194,6 +201,7 @@ const mapCenter = getAverageCoordinates(mapOffices);
             )}
           </aside>
         </div>
+        )}
       </section>
 
       {/* JSON-LD structured data */}

--- a/src/pages/CountryPage.tsx
+++ b/src/pages/CountryPage.tsx
@@ -4,9 +4,10 @@ import companies from "../../data/companies.json";
 import type { Company, Office } from "../types";
 import OfficeCard from "../components/OfficeCard";
 import { MapView } from "../components/MapView";
+import { filterPublishedOffices } from "../utils/officeVisibility";
 
-const allOffices = offices as Office[];
 const allCompanies = companies as Company[];
+const publishedOffices = filterPublishedOffices(offices as Office[]);
 
 function safeJsonLd(value: unknown): string {
   return JSON.stringify(value).replace(/</g, "\\u003c");
@@ -14,7 +15,7 @@ function safeJsonLd(value: unknown): string {
 
 export default function CountryPage() {
   const { code } = useParams<{ code: string }>();
-  const countryOffices = allOffices.filter((o) => o.countryCode === code);
+  const countryOffices = publishedOffices.filter((o) => o.countryCode === code);
 
   if (countryOffices.length === 0) {
     return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,15 +7,16 @@ import CompanyCard from "../components/CompanyCard";
 import { useCompanySearch } from "../hooks/useCompanySearch";
 import { MapView } from "../components/MapView";
 import { getFilteredHomeData } from "../utils/filters";
+import { filterPublishedOffices } from "../utils/officeVisibility";
 
 const allCompanies = companies as Company[];
-const allOffices = offices as Office[];
+const publishedOffices = filterPublishedOffices(offices as Office[]);
 
-const ALL_REGIONS = [...new Set(allOffices.map((o) => o.region))].sort();
+const ALL_REGIONS = [...new Set(publishedOffices.map((o) => o.region))].sort();
 const ALL_INDUSTRIES = [...new Set(allCompanies.map((c) => c.industry))].sort();
-const ALL_OFFICE_TYPES = [...new Set(allOffices.map((o) => o.officeType))].sort();
+const ALL_OFFICE_TYPES = [...new Set(publishedOffices.map((o) => o.officeType))].sort();
 const ALL_COUNTRIES = [
-  ...new Map(allOffices.map((o) => [o.countryCode, o.country])).entries(),
+  ...new Map(publishedOffices.map((o) => [o.countryCode, o.country])).entries(),
 ].sort((a, b) => a[1].localeCompare(b[1]));
 const ALL_COMPANY_NAMES_BY_ID = Object.fromEntries(
   allCompanies.map((company) => [company.id, company.name])
@@ -35,7 +36,7 @@ export default function HomePage() {
 
   const { filteredCompanies, filteredOfficesByCompany, mapOffices } = useMemo(
     () =>
-      getFilteredHomeData(searchResults, allOffices, {
+      getFilteredHomeData(searchResults, publishedOffices, {
         region,
         country,
         industry,
@@ -53,7 +54,7 @@ export default function HomePage() {
   const countryOptions = useMemo(() => {
     if (!region) return ALL_COUNTRIES;
     return ALL_COUNTRIES.filter(([code]) => {
-      const officeInRegion = allOffices.find(
+      const officeInRegion = publishedOffices.find(
         (o) => o.countryCode === code && o.region === region
       );
       return !!officeInRegion;

--- a/src/pages/ReviewQueuePage.tsx
+++ b/src/pages/ReviewQueuePage.tsx
@@ -1,19 +1,23 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import reviewQueue from "../../data/scraper/review-queue.json";
+import offices from "../../data/offices.json";
+import type { Office } from "../types";
 
 type Decision = "approved" | "rejected";
 
+const QUEUE_DECISIONS_KEY = "goef-review-queue-decisions-v1";
+
 interface QueueOffice {
-  id: string;
-  companyId: string;
-  country: string;
-  countryCode: string;
-  region: string;
-  city: string;
-  address: string;
-  postalCode: string;
-  officeType: string;
+  id?: string;
+  companyId?: string;
+  country?: string;
+  countryCode?: string;
+  region?: string;
+  city?: string;
+  address?: string;
+  postalCode?: string;
+  officeType?: string;
   contactUrl?: string;
 }
 
@@ -35,23 +39,76 @@ interface QueueFile {
 }
 
 const queue = reviewQueue as QueueFile;
+const allOffices = offices as Office[];
+
+/** Stable key for persisting approve/reject in the browser across reloads. */
+function queueItemStorageKey(item: QueueItem): string {
+  const o = item.office;
+  return [
+    item.type,
+    item.sourceId,
+    item.queuedAt,
+    String(o.companyId ?? ""),
+    String(o.city ?? ""),
+    String(o.address ?? "").slice(0, 120),
+  ].join("::");
+}
+
+function loadDecisionsFromStorage(): Record<string, Decision | undefined> {
+  try {
+    const raw = localStorage.getItem(QUEUE_DECISIONS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, Decision | undefined>;
+    }
+  } catch {
+    // ignore
+  }
+  return {};
+}
 
 export default function ReviewQueuePage() {
-  const [decisions, setDecisions] = useState<Record<number, Decision | undefined>>({});
+  const [decisions, setDecisions] = useState<Record<string, Decision | undefined>>(loadDecisionsFromStorage);
 
-  const approvedCount = Object.values(decisions).filter((d) => d === "approved").length;
-  const rejectedCount = Object.values(decisions).filter((d) => d === "rejected").length;
-  const pendingCount = queue.items.length - approvedCount - rejectedCount;
+  useEffect(() => {
+    try {
+      localStorage.setItem(QUEUE_DECISIONS_KEY, JSON.stringify(decisions));
+    } catch {
+      // ignore quota / private mode
+    }
+  }, [decisions]);
+
+  const heldBackCatalogOffices = useMemo(
+    () => allOffices.filter((o) => o.approved === false),
+    [],
+  );
+
+  const pendingQueueItems = useMemo(
+    () => queue.items.filter((item) => !decisions[queueItemStorageKey(item)]),
+    [decisions, queue.items],
+  );
+  const approvedQueueItems = useMemo(
+    () => queue.items.filter((item) => decisions[queueItemStorageKey(item)] === "approved"),
+    [decisions, queue.items],
+  );
+  const rejectedQueueItems = useMemo(
+    () => queue.items.filter((item) => decisions[queueItemStorageKey(item)] === "rejected"),
+    [decisions, queue.items],
+  );
+
+  const approvedCount = approvedQueueItems.length;
+  const rejectedCount = rejectedQueueItems.length;
+  const pendingCount = pendingQueueItems.length;
 
   const approvedPayload = useMemo(() => {
-    const approvedItems = queue.items.filter((_, index) => decisions[index] === "approved");
     return {
       generatedAt: queue.generatedAt,
       reviewedAt: new Date().toISOString(),
       minPublishConfidence: queue.minPublishConfidence,
-      approvedItems,
+      approvedItems: approvedQueueItems,
     };
-  }, [decisions]);
+  }, [approvedQueueItems]);
 
   const approvedJsonDataUrl = useMemo(
     () =>
@@ -61,8 +118,74 @@ export default function ReviewQueuePage() {
     [approvedPayload],
   );
 
-  function setDecision(index: number, decision: Decision) {
-    setDecisions((prev) => ({ ...prev, [index]: decision }));
+  function setDecisionForItem(item: QueueItem, decision: Decision) {
+    const key = queueItemStorageKey(item);
+    setDecisions((prev) => ({ ...prev, [key]: decision }));
+  }
+
+  function clearDecisionForItem(item: QueueItem) {
+    const key = queueItemStorageKey(item);
+    setDecisions((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  }
+
+  function renderQueueCard(item: QueueItem) {
+    const key = queueItemStorageKey(item);
+    const decision = decisions[key];
+    const o = item.office;
+    return (
+      <article key={key} className="queue-item-card">
+        <header className="queue-item-header">
+          <h3>
+            {o.companyId ?? "—"} — {o.city ?? "—"}, {o.country ?? o.countryCode ?? "—"}
+          </h3>
+          <span className="meta-pill">
+            {item.confidence} ({item.confidenceScore})
+          </span>
+        </header>
+
+        <p>
+          <strong>Reason:</strong> {item.reason}
+        </p>
+        <p>
+          <strong>Office type:</strong> {o.officeType ?? "—"}
+        </p>
+        <p>
+          <strong>Address:</strong> {o.address ?? "—"} {o.postalCode ?? ""}
+        </p>
+        <p>
+          <strong>Source:</strong>{" "}
+          <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
+            {item.sourceId}
+          </a>
+        </p>
+
+        <div className="queue-actions">
+          <button
+            type="button"
+            className={`btn-approve ${decision === "approved" ? "active" : ""}`}
+            onClick={() => setDecisionForItem(item, "approved")}
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            className={`btn-reject ${decision === "rejected" ? "active" : ""}`}
+            onClick={() => setDecisionForItem(item, "rejected")}
+          >
+            Reject
+          </button>
+          {decision ? (
+            <button type="button" className="btn-reset" onClick={() => clearDecisionForItem(item)}>
+              Clear
+            </button>
+          ) : null}
+        </div>
+      </article>
+    );
   }
 
   return (
@@ -74,14 +197,19 @@ export default function ReviewQueuePage() {
       <header className="page-header">
         <h1>Review Queue</h1>
         <p className="page-subtitle">
-          Low-confidence records awaiting manual approval before publication.
+          Rejected and pending records stay off the public site and are visible here only. Approve entries
+          to export JSON for publication into <code>data/offices.json</code>.
         </p>
       </header>
 
       <section className="review-summary" aria-label="Review summary">
         <div className="stat-box">
           <span className="stat-number">{queue.items.length}</span>
-          <span className="stat-label">Queued</span>
+          <span className="stat-label">Scraper queue items</span>
+        </div>
+        <div className="stat-box">
+          <span className="stat-number">{pendingCount}</span>
+          <span className="stat-label">Pending</span>
         </div>
         <div className="stat-box">
           <span className="stat-number">{approvedCount}</span>
@@ -92,15 +220,17 @@ export default function ReviewQueuePage() {
           <span className="stat-label">Rejected</span>
         </div>
         <div className="stat-box">
-          <span className="stat-number">{pendingCount}</span>
-          <span className="stat-label">Pending</span>
+          <span className="stat-number">{heldBackCatalogOffices.length}</span>
+          <span className="stat-label">Held in catalog (unpublished)</span>
         </div>
       </section>
 
       <section className="info-card">
         <h2>Export approvals</h2>
         <p className="muted">
-          Download the approved subset and feed it into your publish/reconcile workflow.
+          Download JSON for scraper queue items you marked <strong>Approve</strong>. Merge into your
+          publish workflow (for example <code>promote-accepted</code> or a manual edit) so they appear on
+          the main site.
         </p>
         <a
           href={approvedJsonDataUrl}
@@ -115,55 +245,61 @@ export default function ReviewQueuePage() {
         </a>
       </section>
 
-      <section className="queue-items" aria-label="Queued review items">
-        {queue.items.map((item, index) => {
-          const decision = decisions[index];
-          return (
-            <article key={`${item.sourceId}-${item.office.companyId}-${index}`} className="queue-item-card">
-              <header className="queue-item-header">
-                <h3>
-                  {item.office.companyId} — {item.office.city}, {item.office.country}
-                </h3>
-                <span className="meta-pill">
-                  {item.confidence} ({item.confidenceScore})
-                </span>
-              </header>
+      {heldBackCatalogOffices.length > 0 ? (
+        <section className="info-card" aria-label="Unpublished catalog offices">
+          <h2>Unpublished in catalog</h2>
+          <p className="muted">
+            These rows exist in <code>data/offices.json</code> with <code>&quot;approved&quot;: false</code>. They are{" "}
+            <strong>hidden from the public site</strong> and listed only here. Set <code>&quot;approved&quot;:
+            true</code>{" "}
+            (or remove the field) to publish.
+          </p>
+          <ul className="held-back-catalog-list">
+            {heldBackCatalogOffices.map((o) => (
+              <li key={o.id}>
+                <strong>{o.companyId}</strong> — {o.city}, {o.country} ({o.id})
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
 
-              <p>
-                <strong>Reason:</strong> {item.reason}
-              </p>
-              <p>
-                <strong>Office type:</strong> {item.office.officeType}
-              </p>
-              <p>
-                <strong>Address:</strong> {item.office.address} {item.office.postalCode}
-              </p>
-              <p>
-                <strong>Source:</strong>{" "}
-                <a href={item.sourceUrl} target="_blank" rel="noopener noreferrer">
-                  {item.sourceId}
-                </a>
-              </p>
+      <section className="queue-section" aria-label="Pending review">
+        <h2>Pending ({pendingCount})</h2>
+        <p className="muted">No decision yet — not shown on the home, company, or country pages.</p>
+        <div className="queue-items">
+          {pendingQueueItems.length === 0 ? (
+            <p className="muted">No pending scraper items.</p>
+          ) : (
+            pendingQueueItems.map((item) => renderQueueCard(item))
+          )}
+        </div>
+      </section>
 
-              <div className="queue-actions">
-                <button
-                  type="button"
-                  className={`btn-approve ${decision === "approved" ? "active" : ""}`}
-                  onClick={() => setDecision(index, "approved")}
-                >
-                  Approve
-                </button>
-                <button
-                  type="button"
-                  className={`btn-reject ${decision === "rejected" ? "active" : ""}`}
-                  onClick={() => setDecision(index, "rejected")}
-                >
-                  Reject
-                </button>
-              </div>
-            </article>
-          );
-        })}
+      <section className="queue-section" aria-label="Approved for export">
+        <h2>Approved for export ({approvedCount})</h2>
+        <div className="queue-items">
+          {approvedQueueItems.length === 0 ? (
+            <p className="muted">None yet.</p>
+          ) : (
+            approvedQueueItems.map((item) => renderQueueCard(item))
+          )}
+        </div>
+      </section>
+
+      <section className="queue-section queue-section-rejected" aria-label="Rejected items">
+        <h2>Rejected ({rejectedCount})</h2>
+        <p className="muted">
+          Visible on this page only. Rejections are stored in this browser (localStorage) so you can
+          revisit them; they are never shown on the public site.
+        </p>
+        <div className="queue-items">
+          {rejectedQueueItems.length === 0 ? (
+            <p className="muted">None yet.</p>
+          ) : (
+            rejectedQueueItems.map((item) => renderQueueCard(item))
+          )}
+        </div>
       </section>
     </div>
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,4 +20,6 @@ export interface Office {
   latitude?: number;
   longitude?: number;
   contactUrl?: string;
+  /** When false, the office is withheld from the public site until approved. */
+  approved?: boolean;
 }

--- a/src/utils/officeVisibility.ts
+++ b/src/utils/officeVisibility.ts
@@ -1,0 +1,15 @@
+import type { Office } from "../types";
+
+/**
+ * Offices the public site should list. Records without `approved` are treated as
+ * published (legacy / hand-curated data). Scraper output is kept in
+ * `data/scraper/review-queue.json` until promoted; rows in `offices.json` with
+ * `"approved": false` are hidden from the public site and listed on the review-queue page.
+ */
+export function isPublishedOffice(office: Office): boolean {
+  return office.approved !== false;
+}
+
+export function filterPublishedOffices(offices: Office[]): Office[] {
+  return offices.filter(isPublishedOffice);
+}


### PR DESCRIPTION
## Description
Publication gating for offices on the public site (`approved !== false`), a shared `officeVisibility` helper, and scraper workflow changes so new discoveries land in `data/scraper/review-queue.json` until promoted— not silently merged into `offices.json`. The review queue page groups items into pending / approved / rejected (reject decisions stored in `localStorage`), lists catalog rows with `approved: false`, and documents export/promote paths. `SCRAPER_AUTO_ACCEPT` and promote / review-queue-cli paths that write `offices.json` set `approved: true` for published rows.

## Type of Change
- [ ] New company added
- [ ] Company information updated
- [ ] New office(s) added
- [ ] Office information updated
- [ ] Data correction/fix
- [x] Application / tooling change (schemas, UI, scraper; no bulk company/office data edits in this PR)

## Changes Made
- Optional `approved` on `Office` and JSON schema; `src/utils/officeVisibility.ts` + unit tests
- Home, company, and country pages filter to published offices; company empty-state when none published
- Scraper: high-confidence discoveries queued for manual review; run report includes `officesQueuedForManualReview`; `AUTO_ACCEPT` merges with `approved: true`
- `review-queue-cli` `--apply` and `promote-accepted` append/promote with `approved: true`
- Review queue page: sections, held-back catalog list, styles in `App.css`

## Data Validation
- [x] All entries pass JSON schema validation (`npm run validate-data` — unchanged dataset validates with optional `approved`)
- [x] No personally identifiable information (PII) included (no new PII in this PR)
- [x] All URLs are valid and HTTPS (unchanged data)
- [x] Geographic coordinates are accurate (unchanged data)
- [x] No duplicate entries (unchanged data)
- [x] Information is publicly available (unchanged data)

## Verification
- [x] I have verified this information from official sources (N/A — code change; existing data unchanged)
- [x] I have checked for duplicates in existing data (N/A for this diff)
- [x] I have tested data validation locally with `npm run validate-data`

## Testing Instructions
1. Run: `npm run validate-data`
2. Run: `npm test`
3. Run the app locally and confirm home / company / country pages omit offices with `"approved": false` if any are added for testing
4. Open `/review-queue` and confirm pending / approved / rejected grouping and held-back catalog section

## Additional Context
Draft PR for review before merge. Reject/approve for scraper queue items is persisted per browser via `localStorage` (`goef-review-queue-decisions-v1`).

## Sources
- Other: Engineering change only; no new external data sources.

---

### Before submitting:
- [x] I have read the [Contributing Guidelines](https://github.com/zetesel/GlobalOfficeFinder/blob/main/CONTRIBUTING.md)
- [x] My data is accurate and from public sources (existing bundled data unchanged)
- [x] I have validated the JSON locally
- [x] I consent to this data being published under the project's license
