### PR TITLE
fix: push scraper discovery fallback branch before opening manual PR …

### DIFF
--- a/.github/workflows/scraper-discovery.yml
+++ b/.github/workflows/scraper-discovery.yml
@@ -98,6 +98,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin automation/scraper-discovery:refs/remotes/origin/automation/scraper-discovery || true
           git checkout -B automation/scraper-discovery
           git add data/companies.json data/offices.json data/scraper/last-run.json data/scraper/review-queue.json
 

--- a/.github/workflows/scraper-discovery.yml
+++ b/.github/workflows/scraper-discovery.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "Creating PR using available token..."
 
       - name: Create Pull Request with bot token
-        if: env.SCRAPER_BOT_TOKEN != ''
+        if: (github.event_name != 'workflow_dispatch' || inputs.dry_run != 'true') && env.SCRAPER_BOT_TOKEN != ''
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.SCRAPER_BOT_TOKEN }}
@@ -92,8 +92,27 @@ jobs:
             data/scraper/last-run.json
             data/scraper/review-queue.json
 
+      - name: Push discovery branch for manual PR fallback
+        id: fallback_push
+        if: (github.event_name != 'workflow_dispatch' || inputs.dry_run != 'true') && env.SCRAPER_BOT_TOKEN == ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B automation/scraper-discovery
+          git add data/companies.json data/offices.json data/scraper/last-run.json data/scraper/review-queue.json
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit; skipping branch push."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore(data): update discovered companies and offices"
+          git push --force-with-lease --set-upstream origin automation/scraper-discovery
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
       - name: Create Issue to Request PR (fallback)
-        if: env.SCRAPER_BOT_TOKEN == ''
+        if: (github.event_name != 'workflow_dispatch' || inputs.dry_run != 'true') && env.SCRAPER_BOT_TOKEN == '' && steps.fallback_push.outputs.pushed == 'true'
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…issue

Agent-Logs-Url: https://github.com/zetesel/GlobalOfficeFinder/sessions/72e0fc7c-be04-4f85-ae66-5a05bbe3e8ad

## Description
<!-- Describe the data changes you're making -->

## Type of Change
- [ ] New company added
- [ ] Company information updated
- [ ] New office(s) added
- [ ] Office information updated
- [ ] Data correction/fix

## Changes Made
<!-- List specific changes -->

## Data Validation
- [ ] All entries pass JSON schema validation
- [ ] No personally identifiable information (PII) included
- [ ] All URLs are valid and HTTPS
- [ ] Geographic coordinates are accurate
- [ ] No duplicate entries
- [ ] Information is publicly available

## Verification
- [ ] I have verified this information from official sources
- [ ] I have checked for duplicates in existing data
- [ ] I have tested data validation locally with `npm run validate-data`

## Testing Instructions
<!-- How can reviewers verify this change? -->

1. Run: `npm run validate-data`
2. Check that all entries are valid
3. Review the data changes in this PR

## Additional Context
<!-- Any additional information, sources, or context -->

## Sources
<!-- Where did you find this information? -->
- Official company website
- Press release
- Public filing
- Other: _______________

---

### Before submitting:
- [x] I have read the [Contributing Guidelines](https://github.com/zetesel/GlobalOfficeFinder/blob/main/CONTRIBUTING.md)
- [ ] My data is accurate and from public sources
- [ ] I have validated the JSON locally
- [ ] I consent to this data being published under the project's license
