### PR TITLE
fix: require explicit approval for offices on main page

### DIFF
--- a/__tests__/utils/officeVisibility.test.ts
+++ b/__tests__/utils/officeVisibility.test.ts
@@ -15,8 +15,8 @@ const base: Office = {
 };
 
 describe("isPublishedOffice", () => {
-  it("treats missing approved as published", () => {
-    expect(isPublishedOffice(base)).toBe(true);
+  it("returns false for undefined approved", () => {
+    expect(isPublishedOffice(base)).toBe(false);
   });
 
   it("treats approved true as published", () => {
@@ -29,8 +29,8 @@ describe("isPublishedOffice", () => {
 });
 
 describe("filterPublishedOffices", () => {
-  it("keeps offices that are not explicitly rejected", () => {
+  it("keeps only explicitly approved offices", () => {
     const list: Office[] = [base, { ...base, id: "y", approved: true }, { ...base, id: "z", approved: false }];
-    expect(filterPublishedOffices(list)).toEqual([base, { ...base, id: "y", approved: true }]);
+    expect(filterPublishedOffices(list)).toEqual([{ ...base, id: "y", approved: true }]);
   });
 });

--- a/src/utils/officeVisibility.ts
+++ b/src/utils/officeVisibility.ts
@@ -35,7 +35,7 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 export function isPublishedOffice(office: Office): boolean {
-  return office.approved !== false;
+  return office.approved === true;
 }
 
 export function filterPublishedOffices(offices: Office[]): Office[] {


### PR DESCRIPTION
This PR ensures the main page only displays companies with at least one explicitly approved office.\n\n**Changes:**\n- Updated `isPublishedOffice` to require `approved === true`\n- Updated tests to reflect strict approval requirement\n- All 69 tests pass\n\n**Impact:**\nCompanies without approved offices will no longer appear on the homepage.