### PR TITLE
fix: reset office approvals to enforce queue-based publishing

### DIFF
--- a/data/offices.json
+++ b/data/offices.json
@@ -831,7 +831,7 @@
     "country": "Brazil",
     "countryCode": "BR",
     "region": "Americas",
-    "city": "S\u00e3o Paulo",
+    "city": "São Paulo",
     "address": "Av. Pasteur 138-146",
     "postalCode": "22290-240",
     "officeType": "Regional Office",

--- a/data/offices.json
+++ b/data/offices.json
@@ -25,8 +25,7 @@
     "officeType": "Regional Office",
     "latitude": 53.3478,
     "longitude": -6.2439,
-    "contactUrl": "https://www.shopify.com/contact",
-    "approved": true
+    "contactUrl": "https://www.shopify.com/contact"
   },
   {
     "id": "shopify-sg-sin",
@@ -40,8 +39,7 @@
     "officeType": "Regional Office",
     "latitude": 1.2761,
     "longitude": 103.8458,
-    "contactUrl": "https://www.shopify.com/contact",
-    "approved": true
+    "contactUrl": "https://www.shopify.com/contact"
   },
   {
     "id": "abbott-us-abt",
@@ -615,8 +613,7 @@
     "officeType": "Regional Office",
     "latitude": 47.3686,
     "longitude": 8.5392,
-    "contactUrl": "https://about.google/contact/",
-    "approved": true
+    "contactUrl": "https://about.google/contact/"
   },
   {
     "id": "google-de-ham",
@@ -630,8 +627,7 @@
     "officeType": "Regional Office",
     "latitude": 53.5547,
     "longitude": 9.9939,
-    "contactUrl": "https://about.google/locations/",
-    "approved": true
+    "contactUrl": "https://about.google/locations/"
   },
   {
     "id": "google-gb-lon",
@@ -645,8 +641,7 @@
     "officeType": "Regional Office",
     "latitude": 51.5357,
     "longitude": -0.1245,
-    "contactUrl": "https://about.google/locations/",
-    "approved": true
+    "contactUrl": "https://about.google/locations/"
   },
   {
     "id": "google-gb-london",
@@ -660,8 +655,7 @@
     "officeType": "Regional Office",
     "latitude": 51.5154,
     "longitude": -0.131,
-    "contactUrl": "https://about.google/contact/",
-    "approved": true
+    "contactUrl": "https://about.google/contact/"
   },
   {
     "id": "google-jp-tokyo",
@@ -675,8 +669,7 @@
     "officeType": "Regional Office",
     "latitude": 35.6586,
     "longitude": 139.7454,
-    "contactUrl": "https://about.google/contact/",
-    "approved": true
+    "contactUrl": "https://about.google/contact/"
   },
   {
     "id": "google-sg-sin",
@@ -690,8 +683,7 @@
     "officeType": "Regional Office",
     "latitude": 1.2761,
     "longitude": 103.8048,
-    "contactUrl": "https://about.google/locations/",
-    "approved": true
+    "contactUrl": "https://about.google/locations/"
   },
   {
     "id": "google-us-mtv",
@@ -705,8 +697,7 @@
     "officeType": "Headquarters",
     "latitude": 37.422,
     "longitude": -122.0841,
-    "contactUrl": "https://about.google/locations/",
-    "approved": true
+    "contactUrl": "https://about.google/locations/"
   },
   {
     "id": "google-us-new-york",
@@ -720,8 +711,7 @@
     "officeType": "Regional Office",
     "latitude": 40.7484,
     "longitude": -74.006,
-    "contactUrl": "https://about.google/contact/",
-    "approved": true
+    "contactUrl": "https://about.google/contact/"
   },
   {
     "id": "google-us-nyc",
@@ -735,8 +725,7 @@
     "officeType": "Regional Office",
     "latitude": 40.7411,
     "longitude": -74,
-    "contactUrl": "https://about.google/locations/",
-    "approved": true
+    "contactUrl": "https://about.google/locations/"
   },
   {
     "id": "honda-jp-tok",
@@ -842,7 +831,7 @@
     "country": "Brazil",
     "countryCode": "BR",
     "region": "Americas",
-    "city": "São Paulo",
+    "city": "S\u00e3o Paulo",
     "address": "Av. Pasteur 138-146",
     "postalCode": "22290-240",
     "officeType": "Regional Office",
@@ -1534,8 +1523,7 @@
     "officeType": "Headquarters",
     "latitude": 45.4199879,
     "longitude": -75.6970497,
-    "contactUrl": "https://www.shopify.com/contact",
-    "approved": true
+    "contactUrl": "https://www.shopify.com/contact"
   },
   {
     "id": "siemens-cn-bei",
@@ -1558,7 +1546,7 @@
     "countryCode": "DE",
     "region": "Europe",
     "city": "Munich",
-    "address": "Werner-von-Siemens-Straße 1",
+    "address": "Werner-von-Siemens-Stra\u00dfe 1",
     "postalCode": "80333",
     "officeType": "Headquarters",
     "latitude": 48.1351,

--- a/e2e/country-page.spec.ts
+++ b/e2e/country-page.spec.ts
@@ -1,15 +1,20 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test';
+import { approveFirstPendingQueueItem } from './helpers/approve-queue-item';
 
-test('Country page smoke test from homepage', async ({ page }) => {
-  await page.goto('/')
-  const chips = page.locator('.country-chips .chip')
-  const count = await chips.count()
-  if (count > 0) {
-    await chips.first().click()
-    // country page wrapper should appear
-    await expect(page.locator('.country-page')).toBeVisible({ timeout: 5000 })
-  } else {
-    // No country chips; skip this check gracefully
-    test.skip()
-  }
-})
+test('Country page smoke test from homepage after queue approval', async ({ page }) => {
+  await approveFirstPendingQueueItem(page);
+  await page.goto('/');
+
+  const chips = page.locator('.country-chips .chip');
+  await expect(chips.first()).toBeVisible();
+  await chips.first().click();
+
+  await expect(page.locator('.country-page')).toBeVisible({ timeout: 5000 });
+});
+
+test('Review queue lists unpublished catalog offices', async ({ page }) => {
+  await page.goto('/review-queue');
+
+  await expect(page.getByRole('heading', { name: /Unpublished in catalog/i })).toBeVisible();
+  await expect(page.locator('.held-back-catalog-list li').first()).toBeVisible();
+});

--- a/e2e/helpers/approve-queue-item.ts
+++ b/e2e/helpers/approve-queue-item.ts
@@ -1,0 +1,7 @@
+import type { Page } from '@playwright/test';
+
+/** Approve the first pending scraper item on the review queue page. */
+export async function approveFirstPendingQueueItem(page: Page) {
+  await page.goto('/review-queue');
+  await page.locator('[aria-label="Pending review"] .btn-approve').first().click();
+}

--- a/e2e/homepage-map.spec.ts
+++ b/e2e/homepage-map.spec.ts
@@ -1,7 +1,6 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test';
 
-test('Homepage map loads', async ({ page }) => {
-  await page.goto('/')
-  // Leaflet map container commonly rendered as .leaflet-container
-  await expect(page.locator('.leaflet-container')).toBeVisible({ timeout: 5000 })
-})
+test('Homepage map is hidden without published offices', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.leaflet-container')).toHaveCount(0);
+});

--- a/e2e/main.spec.ts
+++ b/e2e/main.spec.ts
@@ -1,195 +1,199 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { approveFirstPendingQueueItem } from './helpers/approve-queue-item';
 
 test.describe('GlobalOfficeFinder E2E Tests', () => {
   test('homepage loads successfully', async ({ page }) => {
     await page.goto('/');
-    
-    // Check page title
+
     await expect(page).toHaveTitle(/GlobalOfficeFinder/i);
-    
-    // Check main heading
+
     const heading = page.getByRole('heading', { name: /Find Company Offices Worldwide/i });
     await expect(heading).toBeVisible();
   });
 
-  test('search by company name', async ({ page }) => {
+  test('homepage hides companies until offices are approved', async ({ page }) => {
     await page.goto('/');
-    
-    // Get the search input
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.results-count')).toContainText('0 companies found');
+    await expect(page.getByText(/No companies match your search/i)).toBeVisible();
+    await expect(page.locator('.company-card')).toHaveCount(0);
+    await expect(page.locator('.country-chips .chip')).toHaveCount(0);
+  });
+
+  test('search by company name returns no public results without approval', async ({ page }) => {
+    await page.goto('/');
+
     const searchInput = page.getByPlaceholder(/search by company/i);
     await expect(searchInput).toBeVisible();
-    
-    // Type in search input
     await searchInput.fill('Google');
-    
-    // Wait for results to appear
     await page.waitForLoadState('networkidle');
-    
-    // Check that Google company card appears
-    const companyCard = page.getByText(/Google/i).first();
-    await expect(companyCard).toBeVisible();
+
+    await expect(page.locator('.results-count')).toContainText('0 companies found');
+    await expect(page.locator('.company-card')).toHaveCount(0);
   });
 
-  test('filter by country', async ({ page }) => {
+  test('filter controls stay available with an empty public catalog', async ({ page }) => {
     await page.goto('/');
-    
-    // Get country select
+
     const countrySelect = page.getByLabel(/country/i).first();
-    await expect(countrySelect).toBeVisible();
-    
-    // Select a country
-    await countrySelect.selectOption('US');
-    
-    // Wait for filter to apply
-    await page.waitForLoadState('networkidle');
-    
-    // Verify page still shows content
-    const companyCard = page.locator('.company-card').first();
-    await expect(companyCard).toBeVisible();
-  });
-
-  test('filter by region', async ({ page }) => {
-    await page.goto('/');
-    
-    // Get region select
     const regionSelect = page.getByLabel(/region/i).first();
+    const industrySelect = page.getByLabel(/industry/i).first();
+
+    await expect(countrySelect).toBeVisible();
     await expect(regionSelect).toBeVisible();
-    
-    // Select a region
-    await regionSelect.selectOption({ label: 'Americas' });
-    
-    // Wait for filter to apply
+    await expect(industrySelect).toBeVisible();
+
+    await expect(countrySelect.locator('option')).toHaveCount(1);
+    await expect(regionSelect.locator('option')).toHaveCount(1);
+
+    await industrySelect.selectOption({ index: 1 });
     await page.waitForLoadState('networkidle');
-    
-    // Verify content is filtered
-    const companyCard = page.locator('.company-card').first();
-    await expect(companyCard).toBeVisible();
+
+    await expect(page.locator('.results-count')).toContainText('0 companies found');
   });
 
-  test('navigate to company detail page', async ({ page }) => {
-    await page.goto('/');
-    
-    // Wait for companies to load
+  test('navigate to company detail page by URL', async ({ page }) => {
+    await page.goto('/company/google');
     await page.waitForLoadState('networkidle');
-    
-    // Click on first company link
-    const firstCompanyLink = page.locator('.company-card a').first();
-    await firstCompanyLink.click();
-    
-    // Wait for navigation
-    await page.waitForLoadState('networkidle');
-    
-    // Verify we're on a company page
-    const heading = page.getByRole('heading', { level: 1 }).first();
-    await expect(heading).toBeVisible();
+
+    await expect(page.getByRole('heading', { level: 1, name: /Google/i })).toBeVisible();
   });
 
-  test('navigate to country page', async ({ page }) => {
-    await page.goto('/');
-    
-    // Wait for content to load
+  test('country page shows not found without approved offices', async ({ page }) => {
+    await page.goto('/country/US');
     await page.waitForLoadState('networkidle');
-    
-    // Look for country link and click it
-    const countryLink = page.locator('a[href*="/country/"]').first();
-    await expect(countryLink).toBeVisible();
-    await countryLink.click();
-    
-    // Wait for navigation
-    await page.waitForLoadState('networkidle');
-    
-    // Verify we're on a country page
-    const heading = page.getByRole('heading', { level: 1 }).first();
-    await expect(heading).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: /Country not found/i })).toBeVisible();
   });
 
-  test('map view displays on homepage', async ({ page }) => {
+  test('map view is hidden without published offices', async ({ page }) => {
     await page.goto('/');
-    
-    // Wait for page to load
     await page.waitForLoadState('networkidle');
-    
-    // Check if map section is visible
-    const mapSection = page.getByText(/Office Locations Map/i);
-    const isMapVisible = await mapSection.isVisible().catch(() => false);
-    
-    if (isMapVisible) {
-      // If map is visible, check that it has rendered
-      const leafletMap = page.locator('.leaflet-container');
-      await expect(leafletMap).toBeVisible();
-    }
+
+    await expect(page.getByText(/Office Locations Map/i)).toHaveCount(0);
+    await expect(page.locator('.leaflet-container')).toHaveCount(0);
   });
 
   test('responsive design - mobile viewport', async ({ page }) => {
-    // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    
+
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    
-    // Check that main content is visible on mobile
-    const mainContent = page.locator('main').first();
-    await expect(mainContent).toBeVisible();
-    
-    // Check that header is visible
-    const header = page.locator('header').first();
-    await expect(header).toBeVisible();
+
+    await expect(page.locator('main').first()).toBeVisible();
+    await expect(page.locator('header').first()).toBeVisible();
   });
 
   test('responsive design - tablet viewport', async ({ page }) => {
-    // Set tablet viewport
     await page.setViewportSize({ width: 768, height: 1024 });
-    
+
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    
-    // Check that main content is visible on tablet
-    const mainContent = page.locator('main').first();
-    await expect(mainContent).toBeVisible();
+
+    await expect(page.locator('main').first()).toBeVisible();
   });
 
   test('search clears and resets', async ({ page }) => {
     await page.goto('/');
-    
-    // Type in search
+
     const searchInput = page.getByPlaceholder(/search by company/i);
     await searchInput.fill('Google');
     await page.waitForLoadState('networkidle');
-    
-    // Clear search
     await searchInput.clear();
     await page.waitForLoadState('networkidle');
-    
-    // Verify search is cleared
+
     await expect(searchInput).toHaveValue('');
   });
-  
-  test('can navigate between pages using breadcrumbs or back', async ({ page }) => {
+
+  test('can navigate between pages using back', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    
-    // Get initial URL
-    const initialUrl = page.url();
-    
-    // Click on first company link
-    const companyLink = page.locator('.company-card a').first();
-    if (await companyLink.isVisible()) {
-      await companyLink.click();
-      await page.waitForLoadState('networkidle');
-      
-      // URL should have changed
-      const newUrl = page.url();
-      expect(newUrl).not.toBe(initialUrl);
-      
-      // Go back
-      await page.goBack();
-      await page.waitForLoadState('networkidle');
-      
-      // Should be back on homepage
-      const heading = page.getByRole('heading', { name: /Find Company Offices Worldwide/i });
-      await expect(heading).toBeVisible();
-    }
+
+    await page.goto('/company/google');
+    await page.waitForLoadState('networkidle');
+    expect(page.url()).toContain('/company/google');
+
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('heading', { name: /Find Company Offices Worldwide/i })).toBeVisible();
+  });
+});
+
+test.describe('GlobalOfficeFinder E2E Tests after queue approval', () => {
+  test.beforeEach(async ({ page }) => {
+    await approveFirstPendingQueueItem(page);
+  });
+
+  test('approved queue item appears on homepage', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.results-count')).not.toContainText('0 companies found');
+    await expect(page.locator('.company-card').first()).toBeVisible();
+  });
+
+  test('filter by country after approval', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const countrySelect = page.getByLabel(/country/i).first();
+    const firstCountry = countrySelect.locator('option').nth(1);
+    const countryCode = await firstCountry.getAttribute('value');
+    expect(countryCode).toBeTruthy();
+
+    await countrySelect.selectOption(countryCode!);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.company-card').first()).toBeVisible();
+  });
+
+  test('filter by region after approval', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const regionSelect = page.getByLabel(/region/i).first();
+    const firstRegion = regionSelect.locator('option').nth(1);
+    const region = await firstRegion.getAttribute('value');
+    expect(region).toBeTruthy();
+
+    await regionSelect.selectOption(region!);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.company-card').first()).toBeVisible();
+  });
+
+  test('navigate to company detail page from homepage', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('.company-card a').first().click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+  });
+
+  test('navigate to country page from homepage', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const countryLink = page.locator('a[href*="/country/"]').first();
+    await expect(countryLink).toBeVisible();
+    await countryLink.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('.country-page')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible();
+  });
+
+  test('map view displays after approval', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/Office Locations Map/i)).toBeVisible();
+    await expect(page.locator('.leaflet-container')).toBeVisible();
   });
 });
 
@@ -211,11 +215,8 @@ test.describe('Accessibility Tests', () => {
 
   test('homepage is keyboard navigable', async ({ page }) => {
     await page.goto('/');
-    
-    // Wait for page to load
     await page.waitForLoadState('networkidle');
-    
-    // Attempt to find a focusable element and programmatically focus it to verify keyboard navigability
+
     const selectors = ['a', 'button', 'input', 'select', 'textarea', '[tabindex]:not([tabindex="-1"])'];
     let found = false;
     for (const sel of selectors) {
@@ -226,41 +227,34 @@ test.describe('Accessibility Tests', () => {
         break;
       }
     }
-    // If we found a focusable element, ensure it received focus
     expect(found).toBeTruthy();
     const focusedTag = await page.evaluate(() => document.activeElement?.tagName?.toLowerCase() ?? '');
-    // Basic sanity: the focused element should be a common interactive tag
     expect(['a', 'button', 'input', 'select', 'textarea']).toContain(focusedTag);
   });
-  
+
   test('all links have accessible names', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    
-    // Get all links
+
     const links = page.locator('a');
     const linkCount = await links.count();
-    
-    // Check that links have accessible text or aria-label
+
     for (let i = 0; i < Math.min(linkCount, 5); i++) {
       const link = links.nth(i);
       const ariaLabel = await link.getAttribute('aria-label');
       const textContent = await link.textContent();
-      
-      // Link should have either aria-label or text content
+
       expect(ariaLabel || textContent).toBeTruthy();
     }
   });
-  
+
   test('form inputs have associated labels', async ({ page }) => {
     await page.goto('/');
-    
-    // Check search input has label
+
     const searchInput = page.getByPlaceholder(/search by company/i);
     const isVisible = await searchInput.isVisible().catch(() => false);
-    
+
     if (isVisible) {
-      // Input should have either a label or placeholder
       const hasLabel = await searchInput.getAttribute('aria-label');
       const hasPlaceholder = await searchInput.getAttribute('placeholder');
       expect(hasLabel || hasPlaceholder).toBeTruthy();

--- a/e2e/shopify-visibility.spec.ts
+++ b/e2e/shopify-visibility.spec.ts
@@ -1,11 +1,9 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '@playwright/test';
 
-test('Shopify offices visible on homepage', async ({ page }) => {
-  await page.goto('/')
-  // Look for Shopify appearances on the homepage content
-  const shopify = page.locator('text=Shopify')
-  await expect(shopify.first()).toBeVisible({ timeout: 5000 }).catch(() => {
-    // If Shopify is not visible (data may not include it yet), still pass this gate as optional
-    // Do not fail the test on absence of Shopify in data for now
-  })
-})
+test('Shopify offices are hidden on homepage without approval', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.locator('.company-card').filter({ hasText: 'Shopify' })).toHaveCount(0);
+  await expect(page.locator('.results-count')).toContainText('0 companies found');
+});

--- a/e2e/smoke/essential.spec.ts
+++ b/e2e/smoke/essential.spec.ts
@@ -2,15 +2,14 @@ import { test, expect } from '@playwright/test';
 
 test('homepage loads successfully', async ({ page }) => {
   await page.goto('/');
-  // Expect the hero title to be visible
   await expect(page.locator('h1')).toHaveText(/Find Company Offices Worldwide/);
 });
 
-test('search by company name loads results', async ({ page }) => {
+test('search by company name shows no public results without approval', async ({ page }) => {
   await page.goto('/');
   const search = page.locator('#search-input');
   await search.fill('Google');
-  // Wait for the Google company link to appear in results
-  await page.waitForSelector('a[href="/company/google"]', { state: 'attached' });
-  await expect(page.locator('a[href="/company/google"]')).toBeVisible();
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('.results-count')).toContainText('0 companies found');
+  await expect(page.locator('a[href="/company/google"]')).toHaveCount(0);
 });


### PR DESCRIPTION
This PR ensures the main page only shows offices explicitly approved via the Review Queue.\n\n**Changes:**\n- Removed pre-existing `approved: true` flags from `data/offices.json`\n- Existing logic now requires `approved === true` (from PR #68)\n- All offices must now go through the review queue to be published\n\n**Impact:**\n- Companies with 0 approved offices will no longer appear on the main page\n- Google, Shopify, and others will be hidden until approved via queue\n- Stats will accurately reflect queue approval status