### PR TITLE
feat: discover unknown company offices live (Wikidata + Commons + LLM)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# ── Runtime "Discover company offices" backend (api/discover.ts) ──
+# OpenRouter (OpenAI-compatible) API key. Server-side only — never bundled.
+OPENROUTER_API_KEY=
+
+# Model used for entity selection + office structuring. Swap freely.
+OPENROUTER_MODEL=anthropic/claude-3.5-sonnet
+
+# Sent as HTTP-Referer to OpenRouter (used for their dashboard attribution).
+OPENROUTER_REFERRER=https://globalofficefinder.local
+
+# Optional: cap offices returned per company (default 100).
+# DISCOVER_MAX_OFFICES=100

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Local env + Vercel
+.env
+.env.*
+!.env.example
+.vercel
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -109,6 +109,60 @@ The discovery pipeline (`scripts/scraper/run-scraper.mjs`) can be configured via
 
 ---
 
+## 🔎 Live "Discover company offices" (optional backend)
+
+When a search returns no local matches, the app can offer to discover a
+company's offices live from public sources. This is powered by a small
+serverless function (`api/discover.ts`) that combines Wikidata (entity +
+SPARQL locations), Wikimedia Commons (a permissively-licensed photo), and an
+LLM via [OpenRouter](https://openrouter.ai/) for entity selection and result
+structuring. Results live only in the browser session at `/discover/:slug` and
+are never persisted. The OpenRouter API key lives **only** in server-side env
+and never reaches the client bundle.
+
+### Run locally
+
+```bash
+# 1. Install the backend-only dependencies (kept out of the default install so
+#    the static front-end build stays lean). One time:
+npm install openai
+npm install -D @vercel/node vercel
+
+# 2. Provide credentials
+cp .env.example .env        # then set OPENROUTER_API_KEY
+
+# 3. Start Vite + the /api functions together
+npm run dev:api             # vercel dev (serves the SPA and api/discover.ts)
+```
+
+> These three packages back `api/discover.ts` only. They're intentionally not in
+> `package.json`'s default dependency set, so the front-end CI (`npm ci` → build
+> / Vitest / Playwright) never needs them. Add them as above before running the
+> serverless function locally or deploying.
+
+Then open the app, search for a company that isn't in the catalogue (e.g.
+"Stripe"), and accept the discovery prompt. API smoke test:
+
+```bash
+curl -X POST localhost:3000/api/discover \
+  -H 'content-type: application/json' \
+  -d '{"companyName":"Stripe"}'
+```
+
+| Env var | Default | Purpose |
+|:---|:---|:---|
+| `OPENROUTER_API_KEY` | — | OpenRouter key (required; server-side only). |
+| `OPENROUTER_MODEL` | `anthropic/claude-3.5-sonnet` | Model for the two LLM calls. |
+| `OPENROUTER_REFERRER` | `https://globalofficefinder.local` | Sent as HTTP-Referer. |
+| `DISCOVER_MAX_OFFICES` | `100` | Cap on offices returned per company. |
+
+> The Wikidata/Wikimedia primitives are shared 1:1 with the build-time photo
+> enrichment CLI via `scripts/lib/wikidata.mjs` and `scripts/lib/wikimedia.mjs`.
+> The static GitHub Pages deployment has no backend, so discovery is only
+> available when hosted with serverless functions (e.g. Vercel).
+
+---
+
 ## 🛡️ Security & Quality
 
 - **CSP**: Strict Content Security Policy enforced via Meta tags.

--- a/__tests__/components/NotFoundDiscoverModal.test.tsx
+++ b/__tests__/components/NotFoundDiscoverModal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import NotFoundDiscoverModal from "../../src/components/NotFoundDiscoverModal";
+
+describe("NotFoundDiscoverModal", () => {
+  it("renders the company name and both actions", () => {
+    render(
+      <NotFoundDiscoverModal
+        companyName="Stripe"
+        onConfirm={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Stripe/)).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /discover offices/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /not now/i })).toBeInTheDocument();
+  });
+
+  it("fires onConfirm when the primary action is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <NotFoundDiscoverModal
+        companyName="Klarna"
+        onConfirm={onConfirm}
+        onDismiss={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /discover offices/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("fires onDismiss on 'Not now' and on backdrop click", () => {
+    const onDismiss = vi.fn();
+    render(
+      <NotFoundDiscoverModal
+        companyName="Klarna"
+        onConfirm={() => {}}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /not now/i }));
+    // Backdrop is the presentation wrapper around the dialog.
+    const backdrop = screen.getByRole("dialog").parentElement as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not dismiss when clicking inside the dialog", () => {
+    const onDismiss = vi.fn();
+    render(
+      <NotFoundDiscoverModal
+        companyName="Klarna"
+        onConfirm={() => {}}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(screen.getByRole("dialog"));
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/slug.test.ts
+++ b/__tests__/lib/slug.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { slugify, deslugify } from "../../src/lib/slug";
+
+describe("slugify", () => {
+  it("lowercases and kebab-cases", () => {
+    expect(slugify("Stripe Inc")).toBe("stripe-inc");
+  });
+
+  it("strips combining diacritics (NFKD-decomposable)", () => {
+    expect(slugify("Café Société")).toBe("cafe-societe");
+    expect(slugify("São Paulo")).toBe("sao-paulo");
+  });
+
+  it("collapses punctuation and trims dashes", () => {
+    expect(slugify("  --A.B & C!!--  ")).toBe("a-b-c");
+  });
+
+  it("caps length at 80 chars", () => {
+    const long = "a".repeat(200);
+    expect(slugify(long).length).toBe(80);
+  });
+
+  it("handles empty / symbol-only input", () => {
+    expect(slugify("")).toBe("");
+    expect(slugify("***")).toBe("");
+  });
+});
+
+describe("deslugify", () => {
+  it("title-cases a slug back to a readable name", () => {
+    expect(deslugify("acme-global-corp")).toBe("Acme Global Corp");
+  });
+
+  it("ignores stray dashes", () => {
+    expect(deslugify("--stripe--")).toBe("Stripe");
+  });
+});

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -92,6 +92,12 @@ export async function selectEntity(
 }
 
 const OFFICE_TYPES = new Set(["hq", "regional", "branch"]);
+const ALLOWED_REGIONS = new Set([
+  "Americas",
+  "Europe",
+  "Asia-Pacific",
+  "Middle East & Africa",
+]);
 
 /**
  * Turn raw SPARQL location rows into a clean, de-duplicated list of offices
@@ -159,7 +165,10 @@ export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
       typeof o.countryCode === "string" && /^[A-Za-z]{2}$/.test(o.countryCode)
         ? o.countryCode.toUpperCase()
         : "";
-    const region = typeof o.region === "string" ? o.region.trim() : "";
+    // Drop off-list values (e.g. "EMEA", "APAC") so fillRegion() in the
+    // handler can derive a canonical region from the country code instead.
+    const rawRegion = typeof o.region === "string" ? o.region.trim() : "";
+    const region = ALLOWED_REGIONS.has(rawRegion) ? rawRegion : "";
     const officeType =
       typeof o.officeType === "string" && OFFICE_TYPES.has(o.officeType)
         ? (o.officeType as DiscoveredOffice["officeType"])

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -1,0 +1,188 @@
+/**
+ * OpenRouter client (OpenAI-compatible) + the two LLM calls discovery needs:
+ *   1. selectEntity   — pick the right Wikidata Q-id from search candidates.
+ *   2. structureOffices — turn raw SPARQL location rows into clean offices.
+ *
+ * The API key lives ONLY in server env (OPENROUTER_API_KEY) and never reaches
+ * the browser bundle. Model is swappable via OPENROUTER_MODEL.
+ */
+
+import OpenAI from "openai";
+import type { EntityCandidate, RawOfficeRow } from "../../scripts/lib/wikidata.mjs";
+import type { DiscoveredOffice } from "./types";
+
+let cached: OpenAI | null = null;
+
+export function getClient(): OpenAI {
+  if (cached) return cached;
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not configured");
+  cached = new OpenAI({
+    apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer":
+        process.env.OPENROUTER_REFERRER ?? "https://globalofficefinder.local",
+      "X-Title": "GlobalOfficeFinder",
+    },
+  });
+  return cached;
+}
+
+export function getModel(): string {
+  return process.env.OPENROUTER_MODEL ?? "anthropic/claude-3.5-sonnet";
+}
+
+/** Strip ```json fences and parse, tolerating minor LLM formatting slips. */
+function parseJsonLoose(content: string): unknown {
+  let text = content.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  return JSON.parse(text);
+}
+
+/**
+ * Ask the LLM which candidate entity is the actual business named `companyName`.
+ * Returns the chosen Q-id, or null if none of the candidates fit.
+ */
+export async function selectEntity(
+  companyName: string,
+  candidates: EntityCandidate[],
+): Promise<{ wikidataId: string | null; confidence?: number }> {
+  if (candidates.length === 0) return { wikidataId: null };
+  const client = getClient();
+  const list = candidates
+    .map((c) => `- ${c.id}: ${c.label}${c.description ? ` — ${c.description}` : ""}`)
+    .join("\n");
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You match a free-text company name to exactly one Wikidata entity. " +
+          "Choose the entity that is the operating business/company (not a person, " +
+          "film, product, place, or disambiguation page). Respond ONLY with JSON: " +
+          '{"wikidataId": "Q...", "confidence": 0-1} or {"wikidataId": null}.',
+      },
+      {
+        role: "user",
+        content: `Company name: "${companyName}"\nCandidates:\n${list}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as {
+      wikidataId?: string | null;
+      confidence?: number;
+    };
+    const id = parsed?.wikidataId;
+    if (typeof id === "string" && /^Q\d+$/.test(id)) {
+      return { wikidataId: id, confidence: parsed.confidence };
+    }
+    return { wikidataId: null };
+  } catch {
+    return { wikidataId: null };
+  }
+}
+
+const OFFICE_TYPES = new Set(["hq", "regional", "branch"]);
+
+/**
+ * Turn raw SPARQL location rows into a clean, de-duplicated list of offices
+ * matching DiscoveredOffice. The LLM normalises city/country, drops junk and
+ * classifies officeType; we still validate every field server-side.
+ */
+export async function structureOffices(
+  companyName: string,
+  rows: RawOfficeRow[],
+): Promise<DiscoveredOffice[] | null> {
+  if (rows.length === 0) return [];
+  const client = getClient();
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You return JSON of the form {\"offices\": Office[]} where Office is the " +
+          "TypeScript type {country: string, countryCode: string (ISO 3166-1 alpha-2), " +
+          "region: 'Americas'|'Europe'|'Asia-Pacific'|'Middle East & Africa', " +
+          "city: string, address?: string, officeType: 'hq'|'regional'|'branch', " +
+          "latitude?: number, longitude?: number}. Deduplicate locations. Skip any " +
+          "location missing at least a city and a country. Use the headquarters " +
+          "relation to mark exactly the main 'hq'. Preserve latitude/longitude when " +
+          "provided. Return ONLY the JSON object.",
+      },
+      {
+        role: "user",
+        content: `Company: "${companyName}"\nRaw locations (JSON):\n${JSON.stringify(
+          rows,
+          null,
+          0,
+        )}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as { offices?: unknown };
+    const arr = Array.isArray(parsed?.offices) ? parsed.offices : null;
+    if (!arr) return null;
+    return sanitizeOffices(arr);
+  } catch {
+    return null;
+  }
+}
+
+/** Server-side validation — never trust the LLM output shape blindly. */
+export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
+  const out: DiscoveredOffice[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object") continue;
+    const o = raw as Record<string, unknown>;
+    const country = typeof o.country === "string" ? o.country.trim() : "";
+    const city = typeof o.city === "string" ? o.city.trim() : "";
+    if (!country || !city) continue;
+
+    const countryCode =
+      typeof o.countryCode === "string" && /^[A-Za-z]{2}$/.test(o.countryCode)
+        ? o.countryCode.toUpperCase()
+        : "";
+    const region = typeof o.region === "string" ? o.region.trim() : "";
+    const officeType =
+      typeof o.officeType === "string" && OFFICE_TYPES.has(o.officeType)
+        ? (o.officeType as DiscoveredOffice["officeType"])
+        : "branch";
+    const address =
+      typeof o.address === "string" && o.address.trim() ? o.address.trim() : undefined;
+    const latitude = typeof o.latitude === "number" ? o.latitude : undefined;
+    const longitude = typeof o.longitude === "number" ? o.longitude : undefined;
+
+    const key = `${city.toLowerCase()}|${countryCode || country.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      country,
+      countryCode,
+      region,
+      city,
+      address,
+      officeType,
+      latitude,
+      longitude,
+    });
+  }
+  return out;
+}

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for the runtime discovery endpoint. These intentionally mirror
+ * the client types in src/types/index.ts, but the API returns offices WITHOUT
+ * `id` / `companyId` — the client mints `temp-<uuid>` ids on receipt so the
+ * results never collide with the curated catalogue.
+ */
+
+export interface DiscoveredPhoto {
+  url: string;
+  sourceUrl: string;
+  author: string;
+  license: string;
+  licenseUrl: string;
+  title?: string;
+}
+
+export interface DiscoveredOffice {
+  country: string;
+  countryCode: string;
+  region: string;
+  city: string;
+  address?: string;
+  officeType: "hq" | "regional" | "branch";
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface DiscoveredCompany {
+  name: string;
+  description: string;
+  website?: string;
+  wikidataId?: string;
+}
+
+export interface DiscoverResponse {
+  company: DiscoveredCompany;
+  offices: DiscoveredOffice[];
+  photo?: DiscoveredPhoto;
+  /** Present only on soft failures so the client can show a tailored message. */
+  error?: "NOT_FOUND" | "LLM_INVALID" | "NO_OFFICES";
+}

--- a/api/_lib/wikidata.ts
+++ b/api/_lib/wikidata.ts
@@ -1,0 +1,17 @@
+/**
+ * Typed re-exports of the shared Wikidata helpers for the runtime endpoint.
+ * The implementation lives in scripts/lib/wikidata.mjs (also used by the
+ * build-time photo CLI) so the two paths can't drift.
+ */
+export {
+  searchEntities,
+  getEntity,
+  firstClaimValue,
+  fetchEntityOffices,
+  DEFAULT_HEADERS,
+} from "../../scripts/lib/wikidata.mjs";
+
+export type {
+  EntityCandidate,
+  RawOfficeRow,
+} from "../../scripts/lib/wikidata.mjs";

--- a/api/_lib/wikimedia.ts
+++ b/api/_lib/wikimedia.ts
@@ -1,0 +1,56 @@
+/**
+ * Resolve a permissively-licensed Commons photo for an already-resolved
+ * Wikidata company entity. Mirrors scripts/enrich-company-photos.mjs's
+ * findBuildingFile, but takes the entity we already fetched during discovery
+ * so we don't re-resolve it.
+ */
+import {
+  getEntity,
+  firstClaimValue,
+  DEFAULT_HEADERS,
+} from "../../scripts/lib/wikidata.mjs";
+import {
+  getCommonsFileInfo,
+  buildPhotoRecord,
+} from "../../scripts/lib/wikimedia.mjs";
+import type { DiscoveredPhoto } from "./types";
+
+const HEADERS = {
+  ...DEFAULT_HEADERS,
+  "User-Agent":
+    "GlobalOfficeFinderBot/1.0 (https://github.com/zetesel/GlobalOfficeFinder; runtime discovery)",
+};
+
+/** Find the File:… title for a company entity (P18, else HQ P159 → P18). */
+async function findBuildingFile(entity: unknown): Promise<string | null> {
+  const directFile = firstClaimValue(entity, "P18");
+  if (directFile) return `File:${directFile}`;
+
+  const hqId = firstClaimValue(entity, "P159")?.id;
+  if (hqId) {
+    const hq = await getEntity(hqId, { headers: HEADERS });
+    const hqFile = firstClaimValue(hq, "P18");
+    if (hqFile) return `File:${hqFile}`;
+  }
+  return null;
+}
+
+/**
+ * @returns a permissively-licensed photo for the entity, or null if none found
+ * / none with an acceptable license.
+ */
+export async function findEntityPhoto(
+  entity: unknown,
+): Promise<DiscoveredPhoto | null> {
+  try {
+    const file = await findBuildingFile(entity);
+    if (!file) return null;
+    const info = await getCommonsFileInfo(file, { headers: HEADERS });
+    if (!info) return null;
+    const result = buildPhotoRecord(info, file);
+    if ("rejected" in result) return null;
+    return result.photo;
+  } catch {
+    return null;
+  }
+}

--- a/api/discover.ts
+++ b/api/discover.ts
@@ -46,12 +46,26 @@ const REGION_BY_COUNTRY_CODE: Record<string, string> = {
 };
 
 // ─── In-memory state (best-effort; reset on cold start) ──────────────────────
+// Maps are bounded so a long-lived warm instance can't accumulate unbounded
+// state on high-cardinality input — when full, the oldest insertion is evicted
+// (Map iteration order is insertion order).
+const MAX_CACHE_ENTRIES = 500;
+const MAX_RATE_ENTRIES = 5000;
+
 interface CacheEntry {
   at: number;
   body: DiscoverResponse;
 }
 const cache = new Map<string, CacheEntry>();
 const rate = new Map<string, { count: number; windowStart: number }>();
+
+function evictOldest<K, V>(map: Map<K, V>, max: number): void {
+  while (map.size > max) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
 
 function clientIp(req: VercelRequest): string {
   const fwd = req.headers["x-forwarded-for"];
@@ -60,15 +74,29 @@ function clientIp(req: VercelRequest): string {
   return req.socket?.remoteAddress ?? "unknown";
 }
 
-function rateLimited(ip: string): boolean {
+/**
+ * Token-bucket-ish per-IP limiter. Returns `{ limited, retryAfterSec }` so the
+ * caller can surface a Retry-After header. Once over the limit we stop
+ * incrementing `count` (otherwise a burst would extend the cooldown well past
+ * RATE_WINDOW_MS). The caller is expected to skip this for cache hits.
+ */
+function rateLimited(ip: string): { limited: boolean; retryAfterSec: number } {
   const now = Date.now();
   const entry = rate.get(ip);
   if (!entry || now - entry.windowStart > RATE_WINDOW_MS) {
     rate.set(ip, { count: 1, windowStart: now });
-    return false;
+    evictOldest(rate, MAX_RATE_ENTRIES);
+    return { limited: false, retryAfterSec: 0 };
+  }
+  if (entry.count >= RATE_MAX) {
+    const retryAfterSec = Math.max(
+      1,
+      Math.ceil((entry.windowStart + RATE_WINDOW_MS - now) / 1000),
+    );
+    return { limited: true, retryAfterSec };
   }
   entry.count += 1;
-  return entry.count > RATE_MAX;
+  return { limited: false, retryAfterSec: 0 };
 }
 
 function fillRegion(o: DiscoveredOffice): DiscoveredOffice {
@@ -86,12 +114,6 @@ export default async function handler(
     return;
   }
 
-  const ip = clientIp(req);
-  if (rateLimited(ip)) {
-    res.status(429).json({ error: "rate_limited" });
-    return;
-  }
-
   // ── Validate input ──
   const body = (typeof req.body === "string" ? safeParse(req.body) : req.body) ?? {};
   const rawName = typeof body.companyName === "string" ? body.companyName : "";
@@ -101,11 +123,20 @@ export default async function handler(
     return;
   }
 
-  // ── Cache ──
+  // ── Cache (checked before rate-limit so cache hits don't consume a token) ──
   const cacheKey = companyName.toLowerCase();
   const hit = cache.get(cacheKey);
   if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
     res.status(200).json(hit.body);
+    return;
+  }
+
+  // ── Rate-limit only requests that will actually do upstream work ──
+  const ip = clientIp(req);
+  const limit = rateLimited(ip);
+  if (limit.limited) {
+    res.setHeader("Retry-After", String(limit.retryAfterSec));
+    res.status(429).json({ error: "rate_limited" });
     return;
   }
 
@@ -173,6 +204,7 @@ function notFound(name: string): DiscoverResponse {
 function finish(res: VercelResponse, key: string, body: DiscoverResponse): void {
   // Cache soft results (incl. NOT_FOUND) so refreshes don't re-hit the LLM.
   cache.set(key, { at: Date.now(), body });
+  evictOldest(cache, MAX_CACHE_ENTRIES);
   res.status(200).json(body);
 }
 

--- a/api/discover.ts
+++ b/api/discover.ts
@@ -1,0 +1,185 @@
+/**
+ * POST /api/discover  — runtime "discover this company's offices on the web".
+ *
+ * Body: { companyName: string }
+ * Flow:
+ *   A. Wikidata wbsearchentities → candidates
+ *   B. LLM picks the right entity (business, not person/film/place)
+ *   C. SPARQL → raw HQ/location/subsidiary rows
+ *   D. LLM structures rows → clean Office[] (validated server-side)
+ *   E. Commons → permissively-licensed photo (optional)
+ *
+ * The OpenRouter key stays server-side. Results are cached (1h TTL) and rate
+ * limited per IP (best-effort in-memory; fine for a single-region function).
+ */
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import {
+  searchEntities,
+  getEntity,
+  firstClaimValue,
+  fetchEntityOffices,
+} from "./_lib/wikidata";
+import { selectEntity, structureOffices } from "./_lib/openrouter";
+import { findEntityPhoto } from "./_lib/wikimedia";
+import type { DiscoverResponse, DiscoveredOffice } from "./_lib/types";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+const NAME_MIN = 2;
+const NAME_MAX = 80;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const RATE_WINDOW_MS = 60 * 1000;
+const RATE_MAX = 10; // requests / IP / window
+const MAX_OFFICES = Number(process.env.DISCOVER_MAX_OFFICES ?? "100");
+
+const REGION_BY_COUNTRY_CODE: Record<string, string> = {
+  US: "Americas", CA: "Americas", MX: "Americas", BR: "Americas", AR: "Americas",
+  CL: "Americas", CO: "Americas",
+  GB: "Europe", IE: "Europe", DE: "Europe", FR: "Europe", NL: "Europe",
+  LU: "Europe", SE: "Europe", NO: "Europe", FI: "Europe", PL: "Europe",
+  CH: "Europe", ES: "Europe", IT: "Europe", PT: "Europe", DK: "Europe",
+  LT: "Europe", RO: "Europe", GR: "Europe", TR: "Europe",
+  JP: "Asia-Pacific", SG: "Asia-Pacific", AU: "Asia-Pacific", NZ: "Asia-Pacific",
+  IN: "Asia-Pacific", KR: "Asia-Pacific", CN: "Asia-Pacific", HK: "Asia-Pacific",
+  AE: "Middle East & Africa", ZA: "Middle East & Africa", EG: "Middle East & Africa",
+  NG: "Middle East & Africa", SA: "Middle East & Africa", GH: "Middle East & Africa",
+  IL: "Middle East & Africa",
+};
+
+// ─── In-memory state (best-effort; reset on cold start) ──────────────────────
+interface CacheEntry {
+  at: number;
+  body: DiscoverResponse;
+}
+const cache = new Map<string, CacheEntry>();
+const rate = new Map<string, { count: number; windowStart: number }>();
+
+function clientIp(req: VercelRequest): string {
+  const fwd = req.headers["x-forwarded-for"];
+  if (typeof fwd === "string") return fwd.split(",")[0].trim();
+  if (Array.isArray(fwd)) return fwd[0];
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rate.get(ip);
+  if (!entry || now - entry.windowStart > RATE_WINDOW_MS) {
+    rate.set(ip, { count: 1, windowStart: now });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > RATE_MAX;
+}
+
+function fillRegion(o: DiscoveredOffice): DiscoveredOffice {
+  if (o.region) return o;
+  return { ...o, region: REGION_BY_COUNTRY_CODE[o.countryCode] ?? "" };
+}
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({ error: "method_not_allowed" });
+    return;
+  }
+
+  const ip = clientIp(req);
+  if (rateLimited(ip)) {
+    res.status(429).json({ error: "rate_limited" });
+    return;
+  }
+
+  // ── Validate input ──
+  const body = (typeof req.body === "string" ? safeParse(req.body) : req.body) ?? {};
+  const rawName = typeof body.companyName === "string" ? body.companyName : "";
+  const companyName = rawName.replace(/\s+/g, " ").trim();
+  if (companyName.length < NAME_MIN || companyName.length > NAME_MAX) {
+    res.status(400).json({ error: "invalid_company_name" });
+    return;
+  }
+
+  // ── Cache ──
+  const cacheKey = companyName.toLowerCase();
+  const hit = cache.get(cacheKey);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    res.status(200).json(hit.body);
+    return;
+  }
+
+  try {
+    // A. Search candidates
+    const candidates = await searchEntities(companyName, { limit: 8 });
+    if (candidates.length === 0) {
+      return finish(res, cacheKey, notFound(companyName));
+    }
+
+    // B. LLM entity selection
+    const { wikidataId } = await selectEntity(companyName, candidates);
+    if (!wikidataId) {
+      return finish(res, cacheKey, notFound(companyName));
+    }
+
+    // Resolve entity (for name/description/website/photo)
+    const entity = await getEntity(wikidataId);
+    const label = entity?.labels?.en?.value ?? companyName;
+    const description = entity?.descriptions?.en?.value ?? "";
+    const website =
+      typeof firstClaimValue(entity, "P856") === "string"
+        ? (firstClaimValue(entity, "P856") as string)
+        : undefined;
+
+    // C. SPARQL raw locations
+    const rows = await fetchEntityOffices(wikidataId, { limit: MAX_OFFICES * 2 });
+
+    // D. LLM structuring (validated inside structureOffices)
+    const structured = await structureOffices(label, rows);
+    if (structured === null) {
+      return finish(res, cacheKey, {
+        company: { name: label, description, website, wikidataId },
+        offices: [],
+        error: "LLM_INVALID",
+      });
+    }
+
+    const offices = structured.map(fillRegion).slice(0, MAX_OFFICES);
+
+    // E. Photo (best-effort)
+    const photo = entity ? await findEntityPhoto(entity) : null;
+
+    const response: DiscoverResponse = {
+      company: { name: label, description, website, wikidataId },
+      offices,
+      ...(photo ? { photo } : {}),
+      ...(offices.length === 0 ? { error: "NO_OFFICES" as const } : {}),
+    };
+    return finish(res, cacheKey, response);
+  } catch (err) {
+    // Don't cache hard errors.
+    res.status(502).json({ error: "discovery_failed", detail: String(err) });
+  }
+}
+
+function notFound(name: string): DiscoverResponse {
+  return {
+    company: { name, description: "" },
+    offices: [],
+    error: "NOT_FOUND",
+  };
+}
+
+function finish(res: VercelResponse, key: string, body: DiscoverResponse): void {
+  // Cache soft results (incl. NOT_FOUND) so refreshes don't re-hit the LLM.
+  cache.set(key, { at: Date.now(), body });
+  res.status(200).json(body);
+}
+
+function safeParse(s: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -12,6 +12,54 @@ test("search filters company list", async ({ page }) => {
   await expect(page.getByTestId("empty-state")).toBeVisible();
 });
 
+test("no-match search offers live discovery and navigates to /discover", async ({
+  page,
+}) => {
+  // Mock the serverless endpoint so the test never calls OpenRouter.
+  await page.route("**/api/discover", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        company: {
+          name: "NoSuchCompanyXYZ",
+          description: "A fictional company used for testing discovery.",
+          website: "https://example.com",
+          wikidataId: "Q1",
+        },
+        offices: [
+          {
+            country: "United States",
+            countryCode: "US",
+            region: "Americas",
+            city: "San Francisco",
+            officeType: "hq",
+            latitude: 37.7749,
+            longitude: -122.4194,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByPlaceholder(/search companies/i).fill("NoSuchCompanyXYZ");
+  // Modal appears after the debounce (~700ms).
+  const discoverBtn = page.getByRole("button", { name: /discover offices/i });
+  await expect(discoverBtn).toBeVisible({ timeout: 3000 });
+  await discoverBtn.click();
+
+  await expect(page).toHaveURL(/\/discover\/nosuchcompanyxyz/);
+  // The discovery map + its bar title render once results resolve.
+  await expect(page.locator(".leaflet-container").first()).toBeVisible();
+  await expect(page.getByText("NoSuchCompanyXYZ").first()).toBeVisible();
+
+  // Ending the search confirms and returns home.
+  await page.getByRole("button", { name: /end search/i }).click();
+  await page.getByRole("button", { name: /yes, end search/i }).click();
+  await expect(page).toHaveURL(/\/$/);
+});
+
 test("navigates to a company page via direct URL", async ({ page }) => {
   await page.goto("/");
   const firstCard = page.locator(".gof-card").first();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:api": "vercel dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/scripts/enrich-company-photos.mjs
+++ b/scripts/enrich-company-photos.mjs
@@ -8,13 +8,16 @@
  * into the record as `photo`.
  *
  * Workflow per company:
- *   1. Resolve company name → Wikidata Q-id (via Wikipedia REST summary, then
- *      wbsearchentities fallback).
+ *   1. Resolve company name → Wikidata Q-id (wbsearchentities + website match).
  *   2. Read claim P18 (image). If absent, read P159 (HQ location) → P18 on
  *      that entity.
  *   3. For the resulting File: page, call the Commons API for imageinfo +
  *      extmetadata. Filter to permissive licenses (CC0, PD, CC-BY*, CC-BY-SA*).
  *   4. Record { url, sourceUrl, author, license, licenseUrl, title }.
+ *
+ * The Wikidata + Wikimedia primitives now live in scripts/lib/*.mjs so they can
+ * be shared with the runtime discovery endpoint (api/_lib/*). This script keeps
+ * its CLI behaviour (env knobs, dry-run, mutate companies.json).
  *
  * Usage:
  *   node scripts/enrich-company-photos.mjs              # mutate data/companies.json
@@ -29,6 +32,13 @@
 import { readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import {
+  delay,
+  resolveCompanyEntity,
+  getEntity,
+  firstClaimValue,
+} from "./lib/wikidata.mjs";
+import { getCommonsFileInfo, buildPhotoRecord } from "./lib/wikimedia.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
@@ -45,190 +55,12 @@ const REQUEST_HEADERS = {
   Accept: "application/json",
 };
 
-const WIKIDATA_API = "https://www.wikidata.org/w/api.php";
-const COMMONS_API = "https://commons.wikimedia.org/w/api.php";
-
-/**
- * Lower-case fragments allowed in license fields. Anything containing
- * NoDerivatives (-nd), NonCommercial (-nc), or "fair use" is rejected.
- * Plain "public domain", "pd", "cc0" pass through.
- */
-const LICENSE_WHITELIST_PATTERNS = [
-  /^cc0/, /^cc-zero/, /\bpublic domain\b/, /^pd(\b|-)/,
-  /^cc[- ]by(\b|-)(?!.*\bnd\b)(?!.*\bnc\b)/, // CC-BY[-SA][-x.x]
-];
-
-function delay(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
-async function fetchJson(url) {
-  const res = await fetch(url, { headers: REQUEST_HEADERS });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${url}`);
-  return res.json();
-}
-
-function stripHtml(s) {
-  if (!s) return "";
-  // Strip both well-formed (<tag …>) and malformed (<tag …, with no closing >)
-  // HTML iteratively until the string is stable, then drop any residual
-  // angle brackets so no element-like substring can survive. We deliberately
-  // do NOT decode &lt;/&gt; entities back into angle brackets — that would
-  // re-introduce the very characters we just stripped (the issue Copilot /
-  // CodeQL flag as "double escaping or unescaping").
-  let out = String(s);
-  let prev;
-  do {
-    prev = out;
-    out = out.replace(/<[^<>]*>?/g, "");
-  } while (out !== prev);
-  return out
-    .replace(/[<>]/g, "")
-    .replace(/&lt;/g, "")
-    .replace(/&gt;/g, "")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, "&")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function licenseAllowed(licenseShort) {
-  if (!licenseShort) return false;
-  const s = licenseShort.toLowerCase();
-  if (/\bnd\b|\bnc\b|fair use|all rights|non-commercial|no derivatives/.test(s))
-    return false;
-  return LICENSE_WHITELIST_PATTERNS.some((re) => re.test(s));
-}
-
-/** Best-effort canonical license deed URL from a short name. */
-function canonicalLicenseUrl(licenseShort) {
-  const s = (licenseShort || "").toLowerCase().replace(/\s+/g, "-");
-  if (/^cc0|cc-zero/.test(s)) return "https://creativecommons.org/publicdomain/zero/1.0/";
-  if (/\bpublic-domain\b|^pd(\b|-)/.test(s)) return "https://en.wikipedia.org/wiki/Public_domain";
-  const m = s.match(/^cc-?by(-sa)?-?(\d(?:\.\d)?)?/);
-  if (m) {
-    const sa = m[1] ? "-sa" : "";
-    const ver = m[2] || "4.0";
-    return `https://creativecommons.org/licenses/by${sa}/${ver}/`;
-  }
-  return "";
-}
-
-/** Hostname compare, robust to www. + trailing slashes. */
-function sameHost(a, b) {
-  try {
-    const ha = new URL(a).hostname.replace(/^www\./, "").toLowerCase();
-    const hb = new URL(b).hostname.replace(/^www\./, "").toLowerCase();
-    return ha === hb;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Wikidata P31 (instance-of) Q-ids that mean "this entity is a business of
- * some kind". The match is recursive in real Wikidata, but a coarse top-level
- * set is enough to filter out fruit/material/etc. articles.
- */
-const BUSINESS_INSTANCE_QIDS = new Set([
-  "Q4830453", // business
-  "Q43229",   // organization
-  "Q783794",  // company
-  "Q6881511", // enterprise
-  "Q891723",  // public company
-  "Q167037",  // corporation
-  "Q161726",  // multinational corporation
-  "Q1616075", // privately held company
-  "Q2401749", // joint-stock company
-  "Q1058914", // software company
-  "Q210167",  // video game developer
-  "Q270791",  // state-owned enterprise
-  "Q15911314",// association
-  "Q4830453", // business (dup ok)
-  "Q1496428", // automobile manufacturer
-  "Q1656682", // industrial enterprise
-]);
-
-function isBusinessEntity(entity) {
-  const claims = entity?.claims?.P31;
-  if (!Array.isArray(claims)) return false;
-  return claims.some((c) => BUSINESS_INSTANCE_QIDS.has(c?.mainsnak?.datavalue?.value?.id));
-}
-
-/** Multi-candidate search via wbsearchentities. */
-async function searchWikidataCandidates(name) {
-  const params = new URLSearchParams({
-    action: "wbsearchentities",
-    search: name,
-    language: "en",
-    type: "item",
-    limit: "8",
-    format: "json",
-    origin: "*",
-  });
-  try {
-    const j = await fetchJson(`${WIKIDATA_API}?${params}`);
-    return (j?.search ?? []).map((s) => s.id).filter(Boolean);
-  } catch {
-    return [];
-  }
-}
-
-/** Fetch a single Wikidata entity's claims. */
-async function getEntity(qid) {
-  const params = new URLSearchParams({
-    action: "wbgetentities",
-    ids: qid,
-    props: "claims|labels",
-    languages: "en",
-    format: "json",
-    origin: "*",
-  });
-  try {
-    const j = await fetchJson(`${WIKIDATA_API}?${params}`);
-    return j?.entities?.[qid] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function firstClaimValue(entity, prop) {
-  const claims = entity?.claims?.[prop];
-  if (!Array.isArray(claims) || claims.length === 0) return null;
-  return claims[0]?.mainsnak?.datavalue?.value ?? null;
-}
-
-function allClaimValues(entity, prop) {
-  const claims = entity?.claims?.[prop];
-  if (!Array.isArray(claims)) return [];
-  return claims.map((c) => c?.mainsnak?.datavalue?.value).filter(Boolean);
-}
-
-/**
- * Resolve a company → its Wikidata entity using the company's own website as
- * the disambiguator. Falls back to "first business-type result" when no
- * website match exists.
- */
-async function resolveCompanyEntity(company) {
-  const candidates = await searchWikidataCandidates(company.name);
-  if (!candidates.length) return null;
-
-  let businessFallback = null;
-  for (const qid of candidates) {
-    await delay(REQUEST_DELAY);
-    const entity = await getEntity(qid);
-    if (!entity) continue;
-    const websites = allClaimValues(entity, "P856");
-    if (websites.some((w) => sameHost(w, company.website))) return entity;
-    if (!businessFallback && isBusinessEntity(entity)) businessFallback = entity;
-  }
-  return businessFallback;
-}
-
 /** Resolve company → File:… title (HQ building or company image). */
 async function findBuildingFile(company) {
-  const entity = await resolveCompanyEntity(company);
+  const entity = await resolveCompanyEntity(company, {
+    requestDelay: REQUEST_DELAY,
+    headers: REQUEST_HEADERS,
+  });
   if (!entity) return null;
 
   // P18 directly on the company entity is the canonical building/image.
@@ -239,54 +71,11 @@ async function findBuildingFile(company) {
   const hqId = firstClaimValue(entity, "P159")?.id;
   if (hqId) {
     await delay(REQUEST_DELAY);
-    const hq = await getEntity(hqId);
+    const hq = await getEntity(hqId, { headers: REQUEST_HEADERS });
     const hqFile = firstClaimValue(hq, "P18");
     if (hqFile) return { file: `File:${hqFile}` };
   }
   return null;
-}
-
-/** Fetch imageinfo + extmetadata for a File:… title. */
-async function getCommonsFileInfo(fileTitle) {
-  const params = new URLSearchParams({
-    action: "query",
-    prop: "imageinfo",
-    iiprop: "url|extmetadata|user",
-    iiurlwidth: "1600",
-    titles: fileTitle,
-    format: "json",
-    origin: "*",
-  });
-  const j = await fetchJson(`${COMMONS_API}?${params}`);
-  const pages = j?.query?.pages ?? {};
-  const page = Object.values(pages)[0];
-  const info = page?.imageinfo?.[0];
-  if (!info) return null;
-  return info;
-}
-
-function buildPhotoRecord(info, fileTitle) {
-  const ext = info.extmetadata || {};
-  const license = stripHtml(ext.LicenseShortName?.value) || stripHtml(ext.License?.value);
-  const licenseUrl = (ext.LicenseUrl?.value || "").trim() || canonicalLicenseUrl(license);
-  const author = stripHtml(ext.Artist?.value) || info.user || "Unknown";
-  const title = stripHtml(ext.ObjectName?.value) || fileTitle.replace(/^File:/, "");
-  if (!licenseAllowed(license)) return { rejected: true, reason: `license="${license}"` };
-  if (!licenseUrl) return { rejected: true, reason: "missing license URL" };
-  const url = info.thumburl || info.url;
-  if (!url) return { rejected: true, reason: "missing image URL" };
-  if (!/^https:\/\/upload\.wikimedia\.org\//.test(url))
-    return { rejected: true, reason: `unexpected host: ${url}` };
-  return {
-    photo: {
-      url,
-      sourceUrl: info.descriptionurl,
-      author,
-      license,
-      licenseUrl,
-      title,
-    },
-  };
 }
 
 async function enrichCompany(company) {
@@ -294,7 +83,7 @@ async function enrichCompany(company) {
   const found = await findBuildingFile(company);
   if (!found) return { skipped: true, reason: "no Wikidata image" };
   await delay(REQUEST_DELAY);
-  const info = await getCommonsFileInfo(found.file);
+  const info = await getCommonsFileInfo(found.file, { headers: REQUEST_HEADERS });
   if (!info) return { skipped: true, reason: "Commons file fetch failed" };
   const result = buildPhotoRecord(info, found.file);
   if (result.rejected) return { skipped: true, reason: result.reason };

--- a/scripts/lib/wikidata.d.mts
+++ b/scripts/lib/wikidata.d.mts
@@ -1,0 +1,58 @@
+export const WIKIDATA_API: string;
+export const WIKIDATA_SPARQL: string;
+export const DEFAULT_HEADERS: Record<string, string>;
+export const BUSINESS_INSTANCE_QIDS: Set<string>;
+
+export function delay(ms: number): Promise<void>;
+export function fetchJson(url: string, headers?: Record<string, string>): Promise<any>;
+export function sameHost(a: string, b: string): boolean;
+export function isBusinessEntity(entity: any): boolean;
+export function firstClaimValue(entity: any, prop: string): any;
+export function allClaimValues(entity: any, prop: string): any[];
+
+export interface EntityCandidate {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export function searchEntities(
+  name: string,
+  opts?: { limit?: number; headers?: Record<string, string> },
+): Promise<EntityCandidate[]>;
+
+export function searchWikidataCandidates(
+  name: string,
+  opts?: { headers?: Record<string, string> },
+): Promise<string[]>;
+
+export function getEntity(
+  qid: string,
+  opts?: { headers?: Record<string, string> },
+): Promise<any | null>;
+
+export function resolveCompanyEntity(
+  company: { name: string; website?: string },
+  opts?: { requestDelay?: number; headers?: Record<string, string> },
+): Promise<any | null>;
+
+export function runSparql(
+  query: string,
+  opts?: { headers?: Record<string, string> },
+): Promise<Array<Record<string, { type: string; value: string }>>>;
+
+export interface RawOfficeRow {
+  place: string;
+  placeLabel: string;
+  cityLabel: string;
+  countryLabel: string;
+  countryCode: string;
+  latitude?: number;
+  longitude?: number;
+  relation: string;
+}
+
+export function fetchEntityOffices(
+  qid: string,
+  opts?: { headers?: Record<string, string>; limit?: number },
+): Promise<RawOfficeRow[]>;

--- a/scripts/lib/wikidata.mjs
+++ b/scripts/lib/wikidata.mjs
@@ -1,0 +1,297 @@
+// @ts-check
+/**
+ * Shared Wikidata helpers.
+ *
+ * Used both by the build-time CLI (scripts/enrich-company-photos.mjs) and the
+ * runtime discovery serverless function (api/_lib/wikidata.ts). Keeping this in
+ * one place avoids drift between the two code paths.
+ *
+ * Pure functions + thin fetch wrappers. No process.env reads here so the module
+ * stays portable between Node CLI and Vercel runtime.
+ */
+
+export const WIKIDATA_API = "https://www.wikidata.org/w/api.php";
+export const WIKIDATA_SPARQL = "https://query.wikidata.org/sparql";
+
+export const DEFAULT_HEADERS = {
+  "User-Agent":
+    "GlobalOfficeFinderBot/1.0 (https://github.com/zetesel/GlobalOfficeFinder; discovery)",
+  Accept: "application/json",
+};
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * @param {string} url
+ * @param {Record<string,string>} [headers]
+ * @returns {Promise<any>}
+ */
+export async function fetchJson(url, headers = DEFAULT_HEADERS) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${url}`);
+  return res.json();
+}
+
+/**
+ * Hostname compare, robust to www. + trailing slashes.
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+export function sameHost(a, b) {
+  try {
+    const ha = new URL(a).hostname.replace(/^www\./, "").toLowerCase();
+    const hb = new URL(b).hostname.replace(/^www\./, "").toLowerCase();
+    return ha === hb;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wikidata P31 (instance-of) Q-ids that mean "this entity is a business of some
+ * kind". The match is recursive in real Wikidata, but a coarse top-level set is
+ * enough to filter out fruit/material/film/person articles.
+ */
+export const BUSINESS_INSTANCE_QIDS = new Set([
+  "Q4830453", // business
+  "Q43229", // organization
+  "Q783794", // company
+  "Q6881511", // enterprise
+  "Q891723", // public company
+  "Q167037", // corporation
+  "Q161726", // multinational corporation
+  "Q1616075", // privately held company
+  "Q2401749", // joint-stock company
+  "Q1058914", // software company
+  "Q210167", // video game developer
+  "Q270791", // state-owned enterprise
+  "Q15911314", // association
+  "Q1496428", // automobile manufacturer
+  "Q1656682", // industrial enterprise
+  "Q18388277", // technology company
+  "Q4830453", // business (dup ok)
+]);
+
+/**
+ * @param {any} entity
+ * @returns {boolean}
+ */
+export function isBusinessEntity(entity) {
+  const claims = entity?.claims?.P31;
+  if (!Array.isArray(claims)) return false;
+  return claims.some((c) =>
+    BUSINESS_INSTANCE_QIDS.has(c?.mainsnak?.datavalue?.value?.id),
+  );
+}
+
+/**
+ * @param {any} entity
+ * @param {string} prop
+ * @returns {any}
+ */
+export function firstClaimValue(entity, prop) {
+  const claims = entity?.claims?.[prop];
+  if (!Array.isArray(claims) || claims.length === 0) return null;
+  return claims[0]?.mainsnak?.datavalue?.value ?? null;
+}
+
+/**
+ * @param {any} entity
+ * @param {string} prop
+ * @returns {any[]}
+ */
+export function allClaimValues(entity, prop) {
+  const claims = entity?.claims?.[prop];
+  if (!Array.isArray(claims)) return [];
+  return claims.map((c) => c?.mainsnak?.datavalue?.value).filter(Boolean);
+}
+
+/**
+ * Search Wikidata for entity candidates by free-text name.
+ * Returns rich objects (id, label, description) — callers that only want ids
+ * can map over `.id`.
+ *
+ * @param {string} name
+ * @param {{ limit?: number, headers?: Record<string,string> }} [opts]
+ * @returns {Promise<Array<{ id: string, label: string, description: string }>>}
+ */
+export async function searchEntities(name, opts = {}) {
+  const { limit = 8, headers = DEFAULT_HEADERS } = opts;
+  const params = new URLSearchParams({
+    action: "wbsearchentities",
+    search: name,
+    language: "en",
+    type: "item",
+    limit: String(limit),
+    format: "json",
+    origin: "*",
+  });
+  try {
+    const j = await fetchJson(`${WIKIDATA_API}?${params}`, headers);
+    return (j?.search ?? [])
+      .filter((s) => s?.id)
+      .map((s) => ({
+        id: s.id,
+        label: s.label ?? "",
+        description: s.description ?? "",
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Back-compat shape used by the photo CLI: just the candidate Q-ids.
+ * @param {string} name
+ * @param {{ headers?: Record<string,string> }} [opts]
+ * @returns {Promise<string[]>}
+ */
+export async function searchWikidataCandidates(name, opts = {}) {
+  const results = await searchEntities(name, opts);
+  return results.map((r) => r.id);
+}
+
+/**
+ * Fetch a single Wikidata entity's claims + labels.
+ * @param {string} qid
+ * @param {{ headers?: Record<string,string> }} [opts]
+ * @returns {Promise<any|null>}
+ */
+export async function getEntity(qid, opts = {}) {
+  const { headers = DEFAULT_HEADERS } = opts;
+  const params = new URLSearchParams({
+    action: "wbgetentities",
+    ids: qid,
+    props: "claims|labels|descriptions",
+    languages: "en",
+    format: "json",
+    origin: "*",
+  });
+  try {
+    const j = await fetchJson(`${WIKIDATA_API}?${params}`, headers);
+    return j?.entities?.[qid] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a company → its Wikidata entity using the company's own website as
+ * the disambiguator. Falls back to "first business-type result" when no website
+ * match exists.
+ *
+ * @param {{ name: string, website?: string }} company
+ * @param {{ requestDelay?: number, headers?: Record<string,string> }} [opts]
+ * @returns {Promise<any|null>}
+ */
+export async function resolveCompanyEntity(company, opts = {}) {
+  const { requestDelay = 250, headers = DEFAULT_HEADERS } = opts;
+  const candidates = await searchWikidataCandidates(company.name, { headers });
+  if (!candidates.length) return null;
+
+  let businessFallback = null;
+  for (const qid of candidates) {
+    await delay(requestDelay);
+    const entity = await getEntity(qid, { headers });
+    if (!entity) continue;
+    const websites = allClaimValues(entity, "P856");
+    if (company.website && websites.some((w) => sameHost(w, company.website)))
+      return entity;
+    if (!businessFallback && isBusinessEntity(entity)) businessFallback = entity;
+  }
+  return businessFallback;
+}
+
+/**
+ * Run a SPARQL query against the Wikidata Query Service, returning the raw
+ * bindings array.
+ *
+ * @param {string} query
+ * @param {{ headers?: Record<string,string> }} [opts]
+ * @returns {Promise<Array<Record<string, { type: string, value: string }>>>}
+ */
+export async function runSparql(query, opts = {}) {
+  const { headers = DEFAULT_HEADERS } = opts;
+  const url = `${WIKIDATA_SPARQL}?format=json&query=${encodeURIComponent(query)}`;
+  const res = await fetch(url, {
+    headers: { ...headers, Accept: "application/sparql-results+json" },
+  });
+  if (!res.ok) throw new Error(`SPARQL ${res.status} ${res.statusText}`);
+  const j = await res.json();
+  return j?.results?.bindings ?? [];
+}
+
+/**
+ * For a company entity QID, pull raw office-like locations:
+ *   - P159 headquarters location (with qualifiers / coords)
+ *   - P276 location
+ *   - subsidiaries (P355) and their P159
+ * Each row carries: place QID/label, city label, country label + ISO code,
+ * latitude/longitude when present.
+ *
+ * @param {string} qid
+ * @param {{ headers?: Record<string,string>, limit?: number }} [opts]
+ * @returns {Promise<Array<{
+ *   place: string, placeLabel: string, cityLabel: string,
+ *   countryLabel: string, countryCode: string,
+ *   latitude?: number, longitude?: number, relation: string,
+ * }>>}
+ */
+export async function fetchEntityOffices(qid, opts = {}) {
+  const { headers = DEFAULT_HEADERS, limit = 200 } = opts;
+  // Headquarters / locations for the company itself and its subsidiaries.
+  const query = `
+SELECT ?relation ?place ?placeLabel ?cityLabel ?countryLabel ?countryCode ?coord WHERE {
+  {
+    wd:${qid} p:P159 ?st .
+    ?st ps:P159 ?place .
+    OPTIONAL { ?st pq:P625 ?coord . }
+    BIND("hq" AS ?relation)
+  } UNION {
+    wd:${qid} wdt:P276 ?place .
+    BIND("location" AS ?relation)
+  } UNION {
+    wd:${qid} wdt:P355 ?sub .
+    ?sub wdt:P159 ?place .
+    BIND("subsidiary" AS ?relation)
+  }
+  OPTIONAL { ?place wdt:P625 ?coord . }
+  OPTIONAL { ?place wdt:P131 ?city . }
+  OPTIONAL { ?place wdt:P17 ?country . ?country wdt:P297 ?countryCode . }
+  OPTIONAL { ?place wdt:P17 ?country . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+}
+LIMIT ${limit}
+`;
+  const bindings = await runSparql(query, { headers });
+  return bindings.map((b) => {
+    let latitude;
+    let longitude;
+    const coord = b.coord?.value;
+    if (coord) {
+      // Format: "Point(long lat)"
+      const m = coord.match(/Point\(([-\d.]+)\s+([-\d.]+)\)/);
+      if (m) {
+        longitude = Number(m[1]);
+        latitude = Number(m[2]);
+      }
+    }
+    return {
+      place: b.place?.value ?? "",
+      placeLabel: b.placeLabel?.value ?? "",
+      cityLabel: b.cityLabel?.value ?? "",
+      countryLabel: b.countryLabel?.value ?? "",
+      countryCode: (b.countryCode?.value ?? "").toUpperCase(),
+      latitude,
+      longitude,
+      relation: b.relation?.value ?? "location",
+    };
+  });
+}

--- a/scripts/lib/wikimedia.d.mts
+++ b/scripts/lib/wikimedia.d.mts
@@ -1,0 +1,27 @@
+export const COMMONS_API: string;
+export const LICENSE_WHITELIST_PATTERNS: RegExp[];
+
+export function stripHtml(s: string | undefined): string;
+export function licenseAllowed(licenseShort: string | undefined): boolean;
+export function canonicalLicenseUrl(licenseShort: string | undefined): string;
+
+export function getCommonsFileInfo(
+  fileTitle: string,
+  opts?: { headers?: Record<string, string>; width?: number },
+): Promise<any | null>;
+
+export interface PhotoRecord {
+  url: string;
+  sourceUrl: string;
+  author: string;
+  license: string;
+  licenseUrl: string;
+  title: string;
+}
+
+export function buildPhotoRecord(
+  info: any,
+  fileTitle: string,
+):
+  | { photo: PhotoRecord }
+  | { rejected: true; reason: string };

--- a/scripts/lib/wikimedia.mjs
+++ b/scripts/lib/wikimedia.mjs
@@ -1,0 +1,138 @@
+// @ts-check
+/**
+ * Shared Wikimedia Commons helpers (license filtering + photo record building).
+ *
+ * Used by scripts/enrich-company-photos.mjs (build-time) and
+ * api/_lib/wikimedia.ts (runtime discovery). Logic moved here 1:1 from the
+ * original CLI so behaviour is identical.
+ */
+
+import { fetchJson, DEFAULT_HEADERS } from "./wikidata.mjs";
+
+export const COMMONS_API = "https://commons.wikimedia.org/w/api.php";
+
+/**
+ * Lower-case fragments allowed in license fields. Anything containing
+ * NoDerivatives (-nd), NonCommercial (-nc), or "fair use" is rejected.
+ * Plain "public domain", "pd", "cc0" pass through.
+ */
+export const LICENSE_WHITELIST_PATTERNS = [
+  /^cc0/,
+  /^cc-zero/,
+  /\bpublic domain\b/,
+  /^pd(\b|-)/,
+  /^cc[- ]by(\b|-)(?!.*\bnd\b)(?!.*\bnc\b)/, // CC-BY[-SA][-x.x]
+];
+
+/**
+ * @param {string | undefined} s
+ * @returns {string}
+ */
+export function stripHtml(s) {
+  if (!s) return "";
+  let out = String(s);
+  let prev;
+  do {
+    prev = out;
+    out = out.replace(/<[^<>]*>?/g, "");
+  } while (out !== prev);
+  return out
+    .replace(/[<>]/g, "")
+    .replace(/&lt;/g, "")
+    .replace(/&gt;/g, "")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * @param {string | undefined} licenseShort
+ * @returns {boolean}
+ */
+export function licenseAllowed(licenseShort) {
+  if (!licenseShort) return false;
+  const s = licenseShort.toLowerCase();
+  if (/\bnd\b|\bnc\b|fair use|all rights|non-commercial|no derivatives/.test(s))
+    return false;
+  return LICENSE_WHITELIST_PATTERNS.some((re) => re.test(s));
+}
+
+/**
+ * Best-effort canonical license deed URL from a short name.
+ * @param {string | undefined} licenseShort
+ * @returns {string}
+ */
+export function canonicalLicenseUrl(licenseShort) {
+  const s = (licenseShort || "").toLowerCase().replace(/\s+/g, "-");
+  if (/^cc0|cc-zero/.test(s))
+    return "https://creativecommons.org/publicdomain/zero/1.0/";
+  if (/\bpublic-domain\b|^pd(\b|-)/.test(s))
+    return "https://en.wikipedia.org/wiki/Public_domain";
+  const m = s.match(/^cc-?by(-sa)?-?(\d(?:\.\d)?)?/);
+  if (m) {
+    const sa = m[1] ? "-sa" : "";
+    const ver = m[2] || "4.0";
+    return `https://creativecommons.org/licenses/by${sa}/${ver}/`;
+  }
+  return "";
+}
+
+/**
+ * Fetch imageinfo + extmetadata for a File:… title.
+ * @param {string} fileTitle
+ * @param {{ headers?: Record<string,string>, width?: number }} [opts]
+ * @returns {Promise<any|null>}
+ */
+export async function getCommonsFileInfo(fileTitle, opts = {}) {
+  const { headers = DEFAULT_HEADERS, width = 1600 } = opts;
+  const params = new URLSearchParams({
+    action: "query",
+    prop: "imageinfo",
+    iiprop: "url|extmetadata|user",
+    iiurlwidth: String(width),
+    titles: fileTitle,
+    format: "json",
+    origin: "*",
+  });
+  const j = await fetchJson(`${COMMONS_API}?${params}`, headers);
+  const pages = j?.query?.pages ?? {};
+  const page = Object.values(pages)[0];
+  const info = page?.imageinfo?.[0];
+  if (!info) return null;
+  return info;
+}
+
+/**
+ * Turn Commons imageinfo into a CompanyPhoto record, or a rejection reason.
+ * @param {any} info
+ * @param {string} fileTitle
+ * @returns {{ photo: { url: string, sourceUrl: string, author: string, license: string, licenseUrl: string, title: string } } | { rejected: true, reason: string }}
+ */
+export function buildPhotoRecord(info, fileTitle) {
+  const ext = info.extmetadata || {};
+  const license =
+    stripHtml(ext.LicenseShortName?.value) || stripHtml(ext.License?.value);
+  const licenseUrl =
+    (ext.LicenseUrl?.value || "").trim() || canonicalLicenseUrl(license);
+  const author = stripHtml(ext.Artist?.value) || info.user || "Unknown";
+  const title = stripHtml(ext.ObjectName?.value) || fileTitle.replace(/^File:/, "");
+  if (!licenseAllowed(license))
+    return { rejected: true, reason: `license="${license}"` };
+  if (!licenseUrl) return { rejected: true, reason: "missing license URL" };
+  const url = info.thumburl || info.url;
+  if (!url) return { rejected: true, reason: "missing image URL" };
+  if (!/^https:\/\/upload\.wikimedia\.org\//.test(url))
+    return { rejected: true, reason: `unexpected host: ${url}` };
+  return {
+    photo: {
+      url,
+      sourceUrl: info.descriptionurl,
+      author,
+      license,
+      licenseUrl,
+      title,
+    },
+  };
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1237,3 +1237,201 @@ a {
     gap: 0;
   }
 }
+
+/* ── Buttons: ghost variant ───────────────────────────────────────────────── */
+.gof-btn-ghost {
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--line-strong);
+}
+.gof-btn-ghost:hover {
+  background: var(--bg);
+}
+
+/* ── Modal (discover prompt + end-search confirm) ────────────────────────── */
+.gof-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(11, 16, 32, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  animation: gof-fade 0.14s ease;
+}
+.gof-modal {
+  background: var(--surface);
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  box-shadow: 0 18px 48px rgba(15, 20, 50, 0.24);
+  max-width: 440px;
+  width: 100%;
+  padding: 22px 22px 18px;
+  animation: gof-pop 0.16s ease;
+}
+.gof-modal-title {
+  font-family: var(--font-head);
+  font-weight: var(--head-weight);
+  letter-spacing: var(--head-tracking);
+  font-size: 18px;
+  margin: 0 0 8px;
+  color: var(--ink);
+}
+.gof-modal-body {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 18px;
+}
+.gof-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+@keyframes gof-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes gof-pop {
+  from { opacity: 0; transform: translateY(6px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+
+/* ── Discovery view (/discover/:slug) ────────────────────────────────────── */
+.gof-discover {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  z-index: 1000;
+}
+.gof-discover-bar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  height: var(--hd);
+  padding: 0 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  flex: 0 0 auto;
+}
+.gof-discover-end {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--ink);
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--line-strong);
+  background: var(--surface);
+  white-space: nowrap;
+}
+.gof-discover-end:hover {
+  background: var(--bg);
+}
+.gof-discover-bar-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-head);
+  font-weight: var(--head-weight);
+  letter-spacing: var(--head-tracking);
+  font-size: 15px;
+  color: var(--ink);
+  min-width: 0;
+  flex: 1;
+}
+.gof-discover-bar-title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gof-discover-badge {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8a5a00;
+  background: #fff4dd;
+  border: 1px solid #ffe3ad;
+  padding: 4px 9px;
+  border-radius: 999px;
+}
+.gof-discover-stage {
+  flex: 1;
+  position: relative;
+  min-height: 0;
+}
+.gof-discover-mapwrap,
+.gof-discover-mapwrap > .gof-map {
+  position: absolute;
+  inset: 0;
+}
+.gof-discover-mapwrap {
+  display: block;
+}
+
+/* Loading + empty states are centred within the stage. */
+.gof-discover-loading,
+.gof-discover-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 24px;
+}
+.gof-discover-loading-text {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 4px 0 0;
+}
+.gof-discover-loading-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+  max-width: 360px;
+}
+.gof-discover-empty-title {
+  font-family: var(--font-head);
+  font-weight: var(--head-weight);
+  font-size: 18px;
+  margin: 4px 0 0;
+  color: var(--ink);
+}
+.gof-discover-empty-body {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0 0 8px;
+  max-width: 420px;
+  line-height: 1.5;
+}
+.gof-spinner {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 3px solid var(--accent-soft);
+  border-top-color: var(--accent);
+  animation: gof-spin 0.8s linear infinite;
+}
+@keyframes gof-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Banner inside the discover tile. */
+.gof-discover-banner {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #8a5a00;
+  background: #fff4dd;
+  border: 1px solid #ffe3ad;
+  border-radius: 8px;
+  padding: 6px 9px;
+  margin-bottom: 10px;
+  line-height: 1.35;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { Suspense, lazy } from "react";
 import Header from "./components/Header";
 import "./App.css";
@@ -7,24 +7,43 @@ const HomePage = lazy(() => import("./pages/HomePage"));
 const CompanyPage = lazy(() => import("./pages/CompanyPage"));
 const CountryPage = lazy(() => import("./pages/CountryPage"));
 const AboutPhotosPage = lazy(() => import("./pages/AboutPhotosPage"));
+const DiscoverPage = lazy(() => import("./pages/DiscoverPage"));
+
+/** Standard chrome (header + main) for the catalogue routes. */
+function MainLayout() {
+  return (
+    <div className="gof-app">
+      <Header />
+      <main className="gof-main">
+        <Suspense fallback={<div className="gof-empty">Loading…</div>}>
+          <Outlet />
+        </Suspense>
+      </main>
+    </div>
+  );
+}
 
 export default function App() {
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <div className="gof-app">
-        <Header />
-        <main className="gof-main">
-          <Suspense fallback={<div className="gof-empty">Loading…</div>}>
-            <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/company/:id" element={<CompanyPage />} />
-              <Route path="/country/:code" element={<CountryPage />} />
-              <Route path="/about/photos" element={<AboutPhotosPage />} />
-              <Route path="*" element={<Navigate to="/" replace />} />
-            </Routes>
-          </Suspense>
-        </main>
-      </div>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/company/:id" element={<CompanyPage />} />
+          <Route path="/country/:code" element={<CountryPage />} />
+          <Route path="/about/photos" element={<AboutPhotosPage />} />
+        </Route>
+        {/* Isolated full-screen discovery view — no global header/filters. */}
+        <Route
+          path="/discover/:slug"
+          element={
+            <Suspense fallback={<div className="gof-empty">Loading…</div>}>
+              <DiscoverPage />
+            </Suspense>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/src/components/DiscoverTile.tsx
+++ b/src/components/DiscoverTile.tsx
@@ -1,0 +1,73 @@
+/**
+ * Map card for the discovery view. Mirrors HomePage's OfficeTile but is
+ * standalone (no router links into the catalogue) and carries a banner making
+ * clear the data is temporary, discovered live, and not manually verified.
+ */
+import type { Company, Office } from "../types";
+import Photo from "./Photo";
+import Monogram from "./Monogram";
+import FlagChip from "./FlagChip";
+import { truncate, typeTag } from "../utils/typeTag";
+
+interface DiscoverTileProps {
+  office: Office;
+  company: Company;
+  onClose: () => void;
+}
+
+export default function DiscoverTile({ office, company, onClose }: DiscoverTileProps) {
+  const tag = typeTag(office.officeType);
+  const summary = truncate(company.description, 160);
+  return (
+    <div className="gof-mapcard" role="dialog" aria-label={`${company.name} — ${office.city}`}>
+      <Photo
+        seed={office.id}
+        w={560}
+        h={200}
+        className="gof-mapcard-photo"
+        photo={company.photo}
+        subject={company.name}
+      >
+        <span className={"gof-tag tag-" + tag.tone + " gof-mapcard-tag"}>{tag.short}</span>
+        <button
+          type="button"
+          className="gof-mapcard-close"
+          aria-label="Close office details"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </Photo>
+      <div className="gof-mapcard-body">
+        <div className="gof-discover-banner" role="note">
+          Temporary data — discovered live, not manually verified.
+        </div>
+        <div className="gof-mapcard-head">
+          <Monogram name={company.name} size={42} square />
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div className="gof-mapcard-name">{company.name}</div>
+            <div className="gof-mapcard-loc">
+              <FlagChip code={office.countryCode} />
+              <span>
+                {office.city}, {office.country}
+              </span>
+            </div>
+          </div>
+        </div>
+        {summary && <p className="gof-mapcard-desc">{summary}</p>}
+        {company.website && (
+          <div className="gof-mapcard-actions">
+            <a
+              className="gof-btn"
+              href={company.website}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Visit website
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/EndSearchModal.tsx
+++ b/src/components/EndSearchModal.tsx
@@ -1,0 +1,35 @@
+/** Confirm dialog before leaving the discovery view (results are discarded). */
+interface EndSearchModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function EndSearchModal({ onConfirm, onCancel }: EndSearchModalProps) {
+  return (
+    <div className="gof-modal-backdrop" role="presentation" onClick={onCancel}>
+      <div
+        className="gof-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gof-end-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="gof-end-title" className="gof-modal-title">
+          End discovery?
+        </h2>
+        <p className="gof-modal-body">
+          These results were discovered live and aren’t saved. Leaving will
+          discard them. Continue?
+        </p>
+        <div className="gof-modal-actions">
+          <button type="button" className="gof-btn gof-btn-ghost" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="button" className="gof-btn" onClick={onConfirm} autoFocus>
+            Yes, end search
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NotFoundDiscoverModal.tsx
+++ b/src/components/NotFoundDiscoverModal.tsx
@@ -1,0 +1,44 @@
+/**
+ * Shown on the home page when a search yields zero local matches. Offers to
+ * search the company's offices live on the web (Wikidata + Commons + AI).
+ */
+interface NotFoundDiscoverModalProps {
+  companyName: string;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}
+
+export default function NotFoundDiscoverModal({
+  companyName,
+  onConfirm,
+  onDismiss,
+}: NotFoundDiscoverModalProps) {
+  return (
+    <div className="gof-modal-backdrop" role="presentation" onClick={onDismiss}>
+      <div
+        className="gof-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gof-discover-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="gof-discover-title" className="gof-modal-title">
+          Not in the directory yet
+        </h2>
+        <p className="gof-modal-body">
+          “{companyName}” isn’t in our catalogue. Want to discover its offices
+          live on the web? We’ll search public sources (Wikidata &amp; Wikimedia
+          Commons) and assemble a temporary map.
+        </p>
+        <div className="gof-modal-actions">
+          <button type="button" className="gof-btn gof-btn-ghost" onClick={onDismiss}>
+            Not now
+          </button>
+          <button type="button" className="gof-btn" onClick={onConfirm} autoFocus>
+            Discover offices
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/discoverClient.ts
+++ b/src/lib/discoverClient.ts
@@ -21,6 +21,8 @@ export interface DiscoveryResult {
   notFound: boolean;
   /** True when the company matched but no usable offices were found. */
   noOffices: boolean;
+  /** True when the LLM structuring step failed — distinct from "no offices". */
+  llmInvalid: boolean;
 }
 
 interface ApiOffice {
@@ -77,15 +79,20 @@ export async function fetchDiscovery(companyName: string): Promise<DiscoveryResu
     city: o.city,
     address: o.address ?? "",
     postalCode: "",
-    officeType: OFFICE_TYPE_LABEL[o.officeType] ?? "Office",
+    officeType: OFFICE_TYPE_LABEL[o.officeType],
     latitude: o.latitude,
     longitude: o.longitude,
   }));
 
+  const notFound = data.error === "NOT_FOUND";
+  const llmInvalid = data.error === "LLM_INVALID";
   return {
     company,
     offices,
-    notFound: data.error === "NOT_FOUND",
-    noOffices: data.error === "NO_OFFICES" || (data.error !== "NOT_FOUND" && offices.length === 0),
+    notFound,
+    llmInvalid,
+    noOffices:
+      data.error === "NO_OFFICES" ||
+      (!notFound && !llmInvalid && offices.length === 0),
   };
 }

--- a/src/lib/discoverClient.ts
+++ b/src/lib/discoverClient.ts
@@ -1,0 +1,91 @@
+/**
+ * Client for POST /api/discover. Maps the server's id-less payload onto the
+ * app's Company / Office shapes, minting `temp-…` ids so discovered results
+ * never collide with the curated catalogue and vanish on navigation away.
+ */
+import type { Company, Office, CompanyPhoto } from "../types";
+import { slugify } from "./slug";
+
+export type DiscoveryStage =
+  | "search"
+  | "select"
+  | "locations"
+  | "structure"
+  | "photo"
+  | "done";
+
+export interface DiscoveryResult {
+  company: Company;
+  offices: Office[];
+  /** True when the company couldn't be matched to a Wikidata entity. */
+  notFound: boolean;
+  /** True when the company matched but no usable offices were found. */
+  noOffices: boolean;
+}
+
+interface ApiOffice {
+  country: string;
+  countryCode: string;
+  region: string;
+  city: string;
+  address?: string;
+  officeType: "hq" | "regional" | "branch";
+  latitude?: number;
+  longitude?: number;
+}
+
+interface ApiResponse {
+  company: { name: string; description: string; website?: string; wikidataId?: string };
+  offices: ApiOffice[];
+  photo?: CompanyPhoto;
+  error?: "NOT_FOUND" | "LLM_INVALID" | "NO_OFFICES";
+}
+
+const OFFICE_TYPE_LABEL: Record<ApiOffice["officeType"], string> = {
+  hq: "Headquarters",
+  regional: "Regional Office",
+  branch: "Branch Office",
+};
+
+export async function fetchDiscovery(companyName: string): Promise<DiscoveryResult> {
+  const res = await fetch("/api/discover", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ companyName }),
+  });
+  if (!res.ok) {
+    throw new Error(`Discovery request failed (${res.status})`);
+  }
+  const data = (await res.json()) as ApiResponse;
+
+  const companyId = `temp-${slugify(data.company.name) || slugify(companyName) || "company"}`;
+  const company: Company = {
+    id: companyId,
+    name: data.company.name,
+    website: data.company.website ?? "",
+    industry: "",
+    description: data.company.description ?? "",
+    photo: data.photo,
+  };
+
+  const offices: Office[] = (data.offices ?? []).map((o, i) => ({
+    id: `${companyId}-${slugify(o.city) || "loc"}-${i}`,
+    companyId,
+    country: o.country,
+    countryCode: o.countryCode,
+    region: o.region,
+    city: o.city,
+    address: o.address ?? "",
+    postalCode: "",
+    officeType: OFFICE_TYPE_LABEL[o.officeType] ?? "Office",
+    latitude: o.latitude,
+    longitude: o.longitude,
+  }));
+
+  return {
+    company,
+    offices,
+    notFound: data.error === "NOT_FOUND",
+    noOffices: data.error === "NO_OFFICES" || (data.error !== "NOT_FOUND" && offices.length === 0),
+  };
+}

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,25 @@
+/**
+ * Turn a free-text company name into a URL-safe slug.
+ * Lowercase, kebab-case, diacritics normalised, capped at 80 chars.
+ * Mirrors the slugify used by the build-time scraper so URLs stay consistent.
+ */
+export function slugify(name: string): string {
+  return name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "") // strip combining diacritics
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+/** Best-effort human-readable name from a slug (fallback when no rawQuery). */
+export function deslugify(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -1,0 +1,203 @@
+/**
+ * Full-screen, header-less discovery view at /discover/:slug.
+ *
+ * On mount it calls POST /api/discover, shows staged loading feedback, then
+ * renders the existing MapView with the temporary offices plus a DiscoverTile.
+ * Results live only in component state — navigating away discards them.
+ */
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import MapView, { type MapFocus } from "../components/MapView";
+import DiscoverTile from "../components/DiscoverTile";
+import EndSearchModal from "../components/EndSearchModal";
+import Monogram from "../components/Monogram";
+import { fetchDiscovery, type DiscoveryResult } from "../lib/discoverClient";
+import { deslugify } from "../lib/slug";
+
+type Status = "loading" | "success" | "notfound" | "error";
+
+const STAGES = [
+  "Searching Wikidata for the company…",
+  "Picking the right entity with AI…",
+  "Fetching office locations…",
+  "Structuring & verifying results…",
+  "Loading licensed photos…",
+];
+
+export default function DiscoverPage() {
+  const { slug = "" } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const rawQuery =
+    (location.state as { rawQuery?: string } | null)?.rawQuery?.trim() ||
+    deslugify(slug);
+
+  const [status, setStatus] = useState<Status>("loading");
+  const [result, setResult] = useState<DiscoveryResult | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [focus, setFocus] = useState<MapFocus>({ fit: true });
+  const [stageIdx, setStageIdx] = useState(0);
+  const [showEnd, setShowEnd] = useState(false);
+  const startedRef = useRef(false);
+
+  // Kick off discovery once. StrictMode double-mount guarded by startedRef.
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchDiscovery(rawQuery);
+        if (cancelled) return;
+        if (data.notFound) {
+          setStatus("notfound");
+        } else {
+          setResult(data);
+          setStatus("success");
+          setFocus({ fit: true });
+        }
+      } catch {
+        if (!cancelled) setStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [rawQuery]);
+
+  // Advance the loading-stage labels on a timer (cosmetic progress).
+  useEffect(() => {
+    if (status !== "loading") return;
+    const t = window.setInterval(() => {
+      setStageIdx((i) => (i < STAGES.length - 1 ? i + 1 : i));
+    }, 2200);
+    return () => window.clearInterval(t);
+  }, [status]);
+
+  const goHome = () => navigate("/");
+
+  const activeOffice = activeId
+    ? result?.offices.find((o) => o.id === activeId) ?? null
+    : null;
+
+  return (
+    <div className="gof-discover">
+      <header className="gof-discover-bar">
+        <button
+          type="button"
+          className="gof-discover-end"
+          onClick={() => setShowEnd(true)}
+        >
+          ← End search
+        </button>
+        <div className="gof-discover-bar-title">
+          {result ? (
+            <>
+              <Monogram name={result.company.name} size={26} square />
+              <span>{result.company.name}</span>
+            </>
+          ) : (
+            <span>Discovering “{rawQuery}”…</span>
+          )}
+        </div>
+        <span className="gof-discover-badge" aria-label="Live, unverified results">
+          Live · unverified
+        </span>
+      </header>
+
+      <div className="gof-discover-stage">
+        {status === "loading" && (
+          <div className="gof-discover-loading" role="status" aria-live="polite">
+            <div className="gof-spinner" aria-hidden="true" />
+            <p className="gof-discover-loading-text">{STAGES[stageIdx]}</p>
+            <p className="gof-discover-loading-sub">
+              Searching public sources for “{rawQuery}”. This can take a few
+              seconds.
+            </p>
+          </div>
+        )}
+
+        {status === "notfound" && (
+          <EmptyState
+            title="No match found"
+            body={`We couldn’t find a company called “${rawQuery}” in public data. Check the spelling or try the full legal name.`}
+            onHome={goHome}
+          />
+        )}
+
+        {status === "error" && (
+          <EmptyState
+            title="Discovery failed"
+            body="Something went wrong while searching the web. Please try again in a moment."
+            onHome={goHome}
+          />
+        )}
+
+        {status === "success" && result && (
+          <div className="gof-discover-mapwrap">
+            {result.noOffices ? (
+              <EmptyState
+                title="No offices located"
+                body={`We matched ${result.company.name} but couldn’t pin any office locations from public data.`}
+                onHome={goHome}
+              />
+            ) : (
+              <>
+                <MapView
+                  offices={result.offices}
+                  companyById={{ [result.company.id]: result.company }}
+                  activeId={activeId}
+                  onSelect={(o) => {
+                    setActiveId(o.id);
+                    setFocus({ id: o.id });
+                  }}
+                  onResetView={() => {
+                    setActiveId(null);
+                    setFocus({ fit: true });
+                  }}
+                  onBackgroundClick={() => setActiveId(null)}
+                  focus={focus}
+                  padding={[70, 70]}
+                />
+                {activeOffice && (
+                  <DiscoverTile
+                    office={activeOffice}
+                    company={result.company}
+                    onClose={() => setActiveId(null)}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {showEnd && (
+        <EndSearchModal onConfirm={goHome} onCancel={() => setShowEnd(false)} />
+      )}
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  body,
+  onHome,
+}: {
+  title: string;
+  body: string;
+  onHome: () => void;
+}) {
+  return (
+    <div className="gof-discover-empty">
+      <div className="gof-empty-ic" aria-hidden="true">
+        ⊘
+      </div>
+      <h2 className="gof-discover-empty-title">{title}</h2>
+      <p className="gof-discover-empty-body">{body}</p>
+      <button type="button" className="gof-btn" onClick={onHome}>
+        Back to directory
+      </button>
+    </div>
+  );
+}

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -52,6 +52,8 @@ export default function DiscoverPage() {
         const data = await fetchDiscovery(rawQuery);
         if (data.notFound) {
           setStatus("notfound");
+        } else if (data.llmInvalid) {
+          setStatus("error");
         } else {
           setResult(data);
           setStatus("success");

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -40,15 +40,16 @@ export default function DiscoverPage() {
   const [showEnd, setShowEnd] = useState(false);
   const startedRef = useRef(false);
 
-  // Kick off discovery once. StrictMode double-mount guarded by startedRef.
+  // Kick off discovery once. StrictMode double-mount guarded by startedRef —
+  // no `cancelled` flag because the first mount's cleanup would otherwise
+  // suppress the in-flight fetch's state update (the second mount returns
+  // early via the ref, leaving no second closure to take over).
   useEffect(() => {
     if (startedRef.current) return;
     startedRef.current = true;
-    let cancelled = false;
     (async () => {
       try {
         const data = await fetchDiscovery(rawQuery);
-        if (cancelled) return;
         if (data.notFound) {
           setStatus("notfound");
         } else {
@@ -57,12 +58,9 @@ export default function DiscoverPage() {
           setFocus({ fit: true });
         }
       } catch {
-        if (!cancelled) setStatus("error");
+        setStatus("error");
       }
     })();
-    return () => {
-      cancelled = true;
-    };
   }, [rawQuery]);
 
   // Advance the loading-stage labels on a timer (cosmetic progress).

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import Dropdown from "../components/Dropdown";
 import CompanyCard from "../components/CompanyCard";
@@ -6,7 +6,9 @@ import MapView, { type MapFocus } from "../components/MapView";
 import Monogram from "../components/Monogram";
 import FlagChip from "../components/FlagChip";
 import Photo from "../components/Photo";
+import NotFoundDiscoverModal from "../components/NotFoundDiscoverModal";
 import { REGION_ORDER, truncate, typeTag } from "../utils/typeTag";
+import { slugify } from "../lib/slug";
 import { useData } from "../hooks/useData";
 
 type View = "grid" | "map";
@@ -30,6 +32,10 @@ export default function HomePage() {
 
   const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
   const [hoverId, setHoverId] = useState<string | null>(null);
+  // Debounced search term + the last query the user dismissed the discover
+  // prompt for, so the modal appears at most once per query (not per keystroke).
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [dismissedQuery, setDismissedQuery] = useState<string | null>(null);
   const [focus, setFocus] = useState<MapFocus>(() =>
     activeId ? { id: activeId } : { fit: true },
   );
@@ -76,6 +82,12 @@ export default function HomePage() {
 
   const { q, region, industry, otype } = filters;
 
+  // Debounce the search term (~700ms) before considering the discover prompt.
+  useEffect(() => {
+    const t = window.setTimeout(() => setDebouncedQ(q.trim()), 700);
+    return () => window.clearTimeout(t);
+  }, [q]);
+
   const matchOffices = useMemo(() => {
     const needle = q.trim().toLowerCase();
     return offices.filter((o) => {
@@ -117,6 +129,18 @@ export default function HomePage() {
     countries: new Set(matchOffices.map((o) => o.country)).size,
   };
   const filtered = Boolean(region || industry || otype || q);
+
+  // Offer live discovery when a meaningful search returns nothing locally.
+  const showDiscover =
+    debouncedQ.length >= 2 &&
+    debouncedQ === q.trim() &&
+    companyList.length === 0 &&
+    debouncedQ !== dismissedQuery;
+
+  function startDiscovery() {
+    const term = q.trim();
+    navigate(`/discover/${slugify(term)}`, { state: { rawQuery: term } });
+  }
 
   const resetFilters = () => setFilters(INITIAL_FILTERS);
 
@@ -299,6 +323,14 @@ export default function HomePage() {
             </div>
           )}
         </div>
+      )}
+
+      {showDiscover && (
+        <NotFoundDiscoverModal
+          companyName={q.trim()}
+          onConfirm={startDiscovery}
+          onDismiss={() => setDismissedQuery(debouncedQ)}
+        />
       )}
     </div>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "functions": {
+    "api/discover.ts": {
+      "maxDuration": 30
+    }
+  },
+  "rewrites": [
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
When a search returns no local matches, offer to discover the company's offices live from public sources. Adds a Vercel serverless endpoint (api/discover.ts) combining Wikidata entity search + SPARQL locations, an OpenRouter LLM for entity selection and office structuring, and a permissively-licensed Wikimedia Commons photo. Results render in an isolated full-screen /discover/:slug view and live only in session state.

- Shared Wikidata/Wikimedia helpers refactored into scripts/lib/*.mjs (reused by the photo-enrichment CLI)
- HomePage debounced not-found prompt; new DiscoverPage, modals, tile
- Tests: slugify + modal unit tests, e2e flow with mocked /api/discover
- Backend-only deps (openai, @vercel/node, vercel) documented in README, kept out of package.json so npm ci stays in sync