### PR TITLE
🧪 [testing improvement] Add tests for FlagChip component

### DIFF
--- a/__tests__/components/FlagChip.test.tsx
+++ b/__tests__/components/FlagChip.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FlagChip from "../../src/components/FlagChip";
+
+describe("FlagChip", () => {
+  it("renders the provided country code", () => {
+    render(<FlagChip code="US" />);
+    expect(screen.getByText("US")).toBeInTheDocument();
+  });
+
+  it("has the correct aria-label", () => {
+    render(<FlagChip code="GB" />);
+    const chip = screen.getByLabelText("Country code GB");
+    expect(chip).toBeInTheDocument();
+  });
+
+  it("renders with different codes", () => {
+    const { rerender } = render(<FlagChip code="FR" />);
+    expect(screen.getByText("FR")).toBeInTheDocument();
+
+    rerender(<FlagChip code="DE" />);
+    expect(screen.getByText("DE")).toBeInTheDocument();
+    expect(screen.getByLabelText("Country code DE")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
The testing gap for the `FlagChip` component was addressed by adding a new test file `__tests__/components/FlagChip.test.tsx`. The scenarios now tested include:
- Verification that the component displays the provided `code` prop as text content.
- Verification that the `aria-label` attribute on the `span` element is correctly set to `Country code ${code}`.
- Verification that the component correctly updates when the `code` prop changes.

This improvement increases the test coverage for stateless UI components in the project.

---
*PR created automatically by Jules for task [5947247804153642328](https://jules.google.com/task/5947247804153642328) started by @lolzegarek*