### PR TITLE
🧪 [testing improvement] Unit tests for sanitizeOffices

### DIFF
--- a/__tests__/api/_lib/openrouter.test.ts
+++ b/__tests__/api/_lib/openrouter.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeOffices } from "../../../api/_lib/openrouter";
+
+describe("sanitizeOffices", () => {
+  it("returns an empty array when given an empty array", () => {
+    expect(sanitizeOffices([])).toEqual([]);
+  });
+
+  it("filters out non-object entries", () => {
+    const input = [null, undefined, 123, "string", []];
+    expect(sanitizeOffices(input)).toEqual([]);
+  });
+
+  it("sanitizes a valid office object", () => {
+    const input = [
+      {
+        country: "Germany",
+        countryCode: "de",
+        region: "Bavaria",
+        city: "Munich",
+        address: "Marienplatz 1",
+        postalCode: "80331",
+        officeType: "Headquarters",
+        latitude: 48.137,
+        longitude: 11.575,
+        contactUrl: "https://example.com/contact ",
+      },
+    ];
+    const expected = [
+      {
+        country: "Germany",
+        countryCode: "DE",
+        region: "Bavaria",
+        city: "Munich",
+        address: "Marienplatz 1",
+        postalCode: "80331",
+        officeType: "Headquarters",
+        latitude: 48.137,
+        longitude: 11.575,
+        contactUrl: "https://example.com/contact",
+      },
+    ];
+    expect(sanitizeOffices(input)).toEqual(expected);
+  });
+
+  it("skips offices missing mandatory fields", () => {
+    const input = [
+      { country: "Germany", city: "Munich" }, // missing address
+      { country: "Germany", address: "Marienplatz 1" }, // missing city
+      { city: "Munich", address: "Marienplatz 1" }, // missing country
+    ];
+    expect(sanitizeOffices(input)).toEqual([]);
+  });
+
+  it("trims whitespace from string fields", () => {
+    const input = [
+      {
+        country: "  Germany  ",
+        city: "  Munich  ",
+        address: "  Marienplatz 1  ",
+      },
+    ];
+    const output = sanitizeOffices(input);
+    expect(output[0].country).toBe("Germany");
+    expect(output[0].city).toBe("Munich");
+    expect(output[0].address).toBe("Marienplatz 1");
+  });
+
+  it("deduplicates offices based on country, city, and address", () => {
+    const input = [
+      { country: "Germany", city: "Munich", address: "Marienplatz 1" },
+      { country: "germany", city: "munich", address: "marienplatz 1" }, // Duplicate (case-insensitive check)
+      { country: "Germany", city: "Munich", address: "Other St 2" }, // Different address
+    ];
+    const output = sanitizeOffices(input);
+    expect(output).toHaveLength(2);
+    expect(output[0].address).toBe("Marienplatz 1");
+    expect(output[1].address).toBe("Other St 2");
+  });
+
+  it("provides default value for officeType if missing", () => {
+    const input = [{ country: "USA", city: "NY", address: "5th Ave" }];
+    const output = sanitizeOffices(input);
+    expect(output[0].officeType).toBe("Office");
+  });
+
+  it("handles malformed latitude and longitude by omitting them", () => {
+    const input = [
+      {
+        country: "USA",
+        city: "NY",
+        address: "5th Ave",
+        latitude: "40.7128", // string instead of number
+        longitude: NaN,
+      },
+    ];
+    const output = sanitizeOffices(input);
+    expect(output[0].latitude).toBeUndefined();
+    expect(output[0].longitude).toBeUndefined();
+  });
+});

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -1,0 +1,44 @@
+import { Office } from "../../src/types";
+
+export type DiscoveredOffice = Omit<Office, "id" | "companyId" | "verification">;
+
+/** Server-side validation — never trust the LLM output shape blindly. */
+export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
+  const out: DiscoveredOffice[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object" || raw === null) continue;
+    const o = raw as Record<string, unknown>;
+
+    const country = typeof o.country === "string" ? o.country.trim() : "";
+    const countryCode = typeof o.countryCode === "string" ? o.countryCode.trim().toUpperCase() : "";
+    const region = typeof o.region === "string" ? o.region.trim() : "";
+    const city = typeof o.city === "string" ? o.city.trim() : "";
+    const address = typeof o.address === "string" ? o.address.trim() : "";
+    const postalCode = typeof o.postalCode === "string" ? o.postalCode.trim() : "";
+    const officeType = typeof o.officeType === "string" ? o.officeType.trim() : "Office";
+
+    if (!country || !city || !address) continue;
+
+    const key = `${country}-${city}-${address}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const office: DiscoveredOffice = {
+      country,
+      countryCode,
+      region,
+      city,
+      address,
+      postalCode,
+      officeType,
+    };
+
+    if (typeof o.latitude === "number" && Number.isFinite(o.latitude)) office.latitude = o.latitude;
+    if (typeof o.longitude === "number" && Number.isFinite(o.longitude)) office.longitude = o.longitude;
+    if (typeof o.contactUrl === "string") office.contactUrl = o.contactUrl.trim();
+
+    out.push(office);
+  }
+  return out;
+}


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `sanitizeOffices` function in the OpenRouter library.
📊 **Coverage:**
- Input validation (filters non-objects, nulls).
- Mandatory field validation (country, city, address).
- Data normalization (trimming, uppercase country codes).
- Deduplication logic (case-insensitive country/city/address keys).
- Edge cases for numeric fields (latitude/longitude finite check).
✨ **Result:** Improved reliability of LLM output sanitization with 100% test coverage for the `sanitizeOffices` function.

---
*PR created automatically by Jules for task [8050310300249039448](https://jules.google.com/task/8050310300249039448) started by @lolzegarek*