### PR TITLE
🧪 [testing improvement] Add missing tests for Header component

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -174,4 +174,69 @@ describe("Header", () => {
     // Thus it renders code ("US").
     expect(within(breadcrumbNav).getByText("US")).toBeInTheDocument();
   });
+
+  it("renders Review link", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const reviewLink = screen.getByRole("link", { name: /^Review$/i });
+    expect(reviewLink).toHaveAttribute("href", "/review");
+  });
+
+  it("renders review breadcrumb on review route", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/review"]}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("Offices")).toHaveAttribute("href", "/");
+    expect(within(breadcrumbNav).getByText("Review")).toBeInTheDocument();
+  });
+
+  it("renders company ID as fallback if company not found", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/company/nonexistent"]}>
+        <Routes>
+          <Route path="/company/:id" element={<Header />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("nonexistent")).toBeInTheDocument();
+  });
+
+  it("renders country name if match found in CountryBreadcrumb", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/country/United States"]}>
+        <Routes>
+          <Route path="/country/:code" element={<Header />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("United States")).toBeInTheDocument();
+  });
+
+  it("renders no breadcrumbs on about photos route", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/about/photos"]}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(breadcrumbNav).toBeEmptyDOMElement();
+  });
 });


### PR DESCRIPTION
### 🧪 Testing Improvement Task: Header Component

This PR addresses the missing test coverage for the `Header` component.

#### 🎯 **What:**
The `Header` component had incomplete testing, specifically regarding its routing-dependent rendering of breadcrumbs and meta links.

#### 📊 **Coverage:**
The following scenarios are now tested in `__tests__/components/Header.test.tsx`:
- **"Review" link**: Verification that the "Review" link is present in the header meta section.
- **`ReviewBreadcrumb`**: Correct rendering of the breadcrumb trail when navigating to `/review`.
- **`CompanyBreadcrumb` fallback**: Ensuring that the company ID is displayed as a fallback when the ID is not found in the catalog data.
- **`CountryBreadcrumb` happy path**: Verification that the country name is correctly displayed when a match is found in the office data.
- **Home/Fall-through breadcrumb**: Ensuring no breadcrumbs are rendered for routes like `/about/photos`.

#### ✨ **Result:**
- Improved the robustness of the `Header` component's navigation logic.
- Increased the `Header.test.tsx` suite from 6 to 11 tests.
- Verified that all new and existing tests pass.
- Verified no regressions in the full unit test suite (56/56 passing).

---
*PR created automatically by Jules for task [16521411323274522729](https://jules.google.com/task/16521411323274522729) started by @lolzegarek*