### PR TITLE
🧪 [testing improvement] Add missing tests for Header component

### DIFF
--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -174,4 +174,57 @@ describe("Header", () => {
     // Thus it renders code ("US").
     expect(within(breadcrumbNav).getByText("US")).toBeInTheDocument();
   });
+
+  it("renders country name if matching office is found", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/country/United States"]}>
+        <Routes>
+          <Route path="/country/:code" element={<Header />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("United States")).toBeInTheDocument();
+  });
+
+  it("renders review breadcrumb on review route", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/review"]}>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("Offices")).toHaveAttribute("href", "/");
+    expect(within(breadcrumbNav).getByText("Review")).toBeInTheDocument();
+  });
+
+  it("renders review link in meta section", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>,
+    );
+
+    const reviewLink = screen.getByRole("link", { name: /^Review$/ });
+    expect(reviewLink).toHaveAttribute("href", "/review");
+  });
+
+  it("renders company ID as fallback if company not found", () => {
+    vi.mocked(useData).mockReturnValue(mockData);
+    render(
+      <MemoryRouter initialEntries={["/company/unknown"]}>
+        <Routes>
+          <Route path="/company/:id" element={<Header />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const breadcrumbNav = screen.getByRole("navigation", { name: /Breadcrumb/i });
+    expect(within(breadcrumbNav).getByText("unknown")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
I have improved the test coverage for the `Header` component by adding missing test cases.

### 🎯 What:
Addressed the testing gap in `src/components/Header.tsx` by covering specific breadcrumb logic and navigation links.

### 📊 Coverage:
The following scenarios are now tested:
- `CountryBreadcrumb`: Verified that it correctly displays the country name when a matching office is found.
- `ReviewBreadcrumb`: Verified that it renders correctly when the user is on the `/review` route.
- Header Meta: Verified the presence and correctness of the "Review" link.
- `CompanyBreadcrumb` Fallback: Verified that it renders the company ID if the company is not found in the catalog.

### ✨ Result:
These additions increase the reliability of the header's navigation and breadcrumb logic, ensuring that users always see appropriate contextual information regardless of the data state or route.

---
*PR created automatically by Jules for task [14519826164992057008](https://jules.google.com/task/14519826164992057008) started by @lolzegarek*