### PR TITLE
🧪 [testing improvement] Add missing unit tests for sanitizeOffices

### DIFF
--- a/__tests__/api/_lib/sanitizer.test.ts
+++ b/__tests__/api/_lib/sanitizer.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeOffices } from "../../../api/_lib/sanitizer";
+
+describe("sanitizeOffices", () => {
+  it("returns an empty array for an empty input", () => {
+    expect(sanitizeOffices([])).toEqual([]);
+  });
+
+  it("skips non-object elements", () => {
+    const input = [null, undefined, 123, "string", []];
+    expect(sanitizeOffices(input as unknown as unknown[])).toEqual([]);
+  });
+
+  it("skips elements missing city or country", () => {
+    const input = [
+      { city: "Berlin" },
+      { country: "Germany" },
+      { city: "", country: "Germany" },
+      { city: "Berlin", country: "" },
+      { city: "  ", country: "Germany" },
+    ];
+    expect(sanitizeOffices(input as unknown as unknown[])).toEqual([]);
+  });
+
+  it("trims city and country names", () => {
+    const input = [{ city: "  Berlin  ", country: "  Germany  " }];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].city).toBe("Berlin");
+    expect(result[0].country).toBe("Germany");
+  });
+
+  it("normalizes countryCode to uppercase", () => {
+    const input = [{ city: "Berlin", country: "Germany", countryCode: "de" }];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].countryCode).toBe("DE");
+  });
+
+  it("ignores invalid countryCode", () => {
+    const input = [
+      { city: "Berlin", country: "Germany", countryCode: "GER" },
+      { city: "Paris", country: "France", countryCode: "1" },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].countryCode).toBe("");
+    expect(result[1].countryCode).toBe("");
+  });
+
+  it("validates region against allowed set", () => {
+    const input = [
+      { city: "Berlin", country: "Germany", region: "Europe" },
+      { city: "New York", country: "USA", region: "Mars" },
+      { city: "Tokyo", country: "Japan", region: "Asia-Pacific" },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].region).toBe("Europe");
+    expect(result[1].region).toBe("");
+    expect(result[2].region).toBe("Asia-Pacific");
+  });
+
+  it("validates officeType against allowed set, defaulting to branch", () => {
+    const input = [
+      { city: "Berlin", country: "Germany", officeType: "hq" },
+      { city: "London", country: "UK", officeType: "regional" },
+      { city: "Paris", country: "France", officeType: "branch" },
+      { city: "Dublin", country: "Ireland", officeType: "coffee-shop" },
+      { city: "Sydney", country: "Australia" },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].officeType).toBe("hq");
+    expect(result[1].officeType).toBe("regional");
+    expect(result[2].officeType).toBe("branch");
+    expect(result[3].officeType).toBe("branch");
+    expect(result[4].officeType).toBe("branch");
+  });
+
+  it("handles optional fields address, latitude, and longitude", () => {
+    const input = [
+      {
+        city: "Berlin",
+        country: "Germany",
+        address: "Mauerstrasse 1",
+        latitude: 52.52,
+        longitude: 13.405,
+      },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0]).toEqual({
+      city: "Berlin",
+      country: "Germany",
+      countryCode: "",
+      region: "",
+      address: "Mauerstrasse 1",
+      officeType: "branch",
+      latitude: 52.52,
+      longitude: 13.405,
+    });
+  });
+
+  it("trims address if present", () => {
+    const input = [{ city: "Berlin", country: "Germany", address: "  Street 1  " }];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].address).toBe("Street 1");
+  });
+
+  it("ignores non-numeric latitude or longitude", () => {
+    const input = [
+      {
+        city: "Berlin",
+        country: "Germany",
+        latitude: "52.52",
+        longitude: [13.405],
+      },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].latitude).toBeUndefined();
+    expect(result[0].longitude).toBeUndefined();
+  });
+
+  it("deduplicates based on lowercase city and country/countryCode", () => {
+    const input = [
+      { city: "Berlin", country: "Germany" },
+      { city: "berlin", country: "GERMANY" },
+      { city: "Berlin", country: "Germany", countryCode: "DE" },
+      { city: "Paris", country: "France" },
+      { city: "PARIS", country: "France", countryCode: "FR" },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    // Logic: key = `${city.toLowerCase()}|${countryCode || country.toLowerCase()}`;
+    // 1st: "berlin|germany"
+    // 2nd: "berlin|germany" (seen)
+    // 3rd: "berlin|de" (new)
+    // 4th: "paris|france"
+    // 5th: "paris|fr" (new)
+    expect(result).toHaveLength(4);
+    expect(result[0].city).toBe("Berlin");
+    expect(result[1].city).toBe("Berlin");
+    expect(result[1].countryCode).toBe("DE");
+    expect(result[2].city).toBe("Paris");
+    expect(result[3].city).toBe("PARIS");
+    expect(result[3].countryCode).toBe("FR");
+  });
+});

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenRouter client (OpenAI-compatible) + the two LLM calls discovery needs:
+ *   1. selectEntity   — pick the right Wikidata Q-id from search candidates.
+ *   2. structureOffices — turn raw SPARQL location rows into clean offices.
+ *
+ * The API key lives ONLY in server env (OPENROUTER_API_KEY) and never reaches
+ * the browser bundle. Model is swappable via OPENROUTER_MODEL.
+ */
+
+import OpenAI from "openai";
+import type { EntityCandidate, RawOfficeRow } from "../../scripts/lib/wikidata.mjs";
+import type { DiscoveredOffice } from "./types";
+import { sanitizeOffices } from "./sanitizer";
+
+let cached: OpenAI | null = null;
+
+export function getClient(): OpenAI {
+  if (cached) return cached;
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not configured");
+  cached = new OpenAI({
+    apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer":
+        process.env.OPENROUTER_REFERRER ?? "https://globalofficefinder.local",
+      "X-Title": "GlobalOfficeFinder",
+    },
+  });
+  return cached;
+}
+
+export function getModel(): string {
+  return process.env.OPENROUTER_MODEL ?? "anthropic/claude-3.5-sonnet";
+}
+
+/** Strip ```json fences and parse, tolerating minor LLM formatting slips. */
+function parseJsonLoose(content: string): unknown {
+  let text = content.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  return JSON.parse(text);
+}
+
+/**
+ * Ask the LLM which candidate entity is the actual business named `companyName`.
+ * Returns the chosen Q-id, or null if none of the candidates fit.
+ */
+export async function selectEntity(
+  companyName: string,
+  candidates: EntityCandidate[],
+): Promise<{ wikidataId: string | null; confidence?: number }> {
+  if (candidates.length === 0) return { wikidataId: null };
+  const client = getClient();
+  const list = candidates
+    .map((c) => `- ${c.id}: ${c.label}${c.description ? ` — ${c.description}` : ""}`)
+    .join("\n");
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You match a free-text company name to exactly one Wikidata entity. " +
+          "Choose the entity that is the operating business/company (not a person, " +
+          "film, product, place, or disambiguation page). Respond ONLY with JSON: " +
+          '{"wikidataId": "Q...", "confidence": 0-1} or {"wikidataId": null}.',
+      },
+      {
+        role: "user",
+        content: `Company name: "${companyName}"\nCandidates:\n${list}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as {
+      wikidataId?: string | null;
+      confidence?: number;
+    };
+    const id = parsed?.wikidataId;
+    if (typeof id === "string" && /^Q\d+$/.test(id)) {
+      return { wikidataId: id, confidence: parsed.confidence };
+    }
+    return { wikidataId: null };
+  } catch {
+    return { wikidataId: null };
+  }
+}
+
+/**
+ * Turn raw SPARQL location rows into a clean, de-duplicated list of offices
+ * matching DiscoveredOffice. The LLM normalises city/country, drops junk and
+ * classifies officeType; we still validate every field server-side.
+ */
+export async function structureOffices(
+  companyName: string,
+  rows: RawOfficeRow[],
+): Promise<DiscoveredOffice[] | null> {
+  if (rows.length === 0) return [];
+  const client = getClient();
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You return JSON of the form {\"offices\": Office[]} where Office is the " +
+          "TypeScript type {country: string, countryCode: string (ISO 3166-1 alpha-2), " +
+          "region: 'Americas'|'Europe'|'Asia-Pacific'|'Middle East & Africa', " +
+          "city: string, address?: string, officeType: 'hq'|'regional'|'branch', " +
+          "latitude?: number, longitude?: number}. Deduplicate locations. Skip any " +
+          "location missing at least a city and a country. Use the headquarters " +
+          "relation to mark exactly the main 'hq'. Preserve latitude/longitude when " +
+          "provided. Return ONLY the JSON object.",
+      },
+      {
+        role: "user",
+        content: `Company: "${companyName}"\nRaw locations (JSON):\n${JSON.stringify(
+          rows,
+          null,
+          0,
+        )}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as { offices?: unknown };
+    const arr = Array.isArray(parsed?.offices) ? parsed.offices : null;
+    if (!arr) return null;
+    return sanitizeOffices(arr);
+  } catch {
+    return null;
+  }
+}

--- a/api/_lib/sanitizer.ts
+++ b/api/_lib/sanitizer.ts
@@ -1,0 +1,55 @@
+import type { DiscoveredOffice } from "./types";
+
+const OFFICE_TYPES = new Set(["hq", "regional", "branch"]);
+const ALLOWED_REGIONS = new Set([
+  "Americas",
+  "Europe",
+  "Asia-Pacific",
+  "Middle East & Africa",
+]);
+
+/** Server-side validation — never trust the LLM output shape blindly. */
+export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
+  const out: DiscoveredOffice[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object") continue;
+    const o = raw as Record<string, unknown>;
+    const country = typeof o.country === "string" ? o.country.trim() : "";
+    const city = typeof o.city === "string" ? o.city.trim() : "";
+    if (!country || !city) continue;
+
+    const countryCode =
+      typeof o.countryCode === "string" && /^[A-Za-z]{2}$/.test(o.countryCode)
+        ? o.countryCode.toUpperCase()
+        : "";
+    // Drop off-list values (e.g. "EMEA", "APAC") so fillRegion() in the
+    // handler can derive a canonical region from the country code instead.
+    const rawRegion = typeof o.region === "string" ? o.region.trim() : "";
+    const region = ALLOWED_REGIONS.has(rawRegion) ? rawRegion : "";
+    const officeType =
+      typeof o.officeType === "string" && OFFICE_TYPES.has(o.officeType)
+        ? (o.officeType as DiscoveredOffice["officeType"])
+        : "branch";
+    const address =
+      typeof o.address === "string" && o.address.trim() ? o.address.trim() : undefined;
+    const latitude = typeof o.latitude === "number" ? o.latitude : undefined;
+    const longitude = typeof o.longitude === "number" ? o.longitude : undefined;
+
+    const key = `${city.toLowerCase()}|${countryCode || country.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      country,
+      countryCode,
+      region,
+      city,
+      address,
+      officeType,
+      latitude,
+      longitude,
+    });
+  }
+  return out;
+}

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for the runtime discovery endpoint. These intentionally mirror
+ * the client types in src/types/index.ts, but the API returns offices WITHOUT
+ * `id` / `companyId` — the client mints `temp-<uuid>` ids on receipt so the
+ * results never collide with the curated catalogue.
+ */
+
+export interface DiscoveredPhoto {
+  url: string;
+  sourceUrl: string;
+  author: string;
+  license: string;
+  licenseUrl: string;
+  title?: string;
+}
+
+export interface DiscoveredOffice {
+  country: string;
+  countryCode: string;
+  region: string;
+  city: string;
+  address?: string;
+  officeType: "hq" | "regional" | "branch";
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface DiscoveredCompany {
+  name: string;
+  description: string;
+  website?: string;
+  wikidataId?: string;
+}
+
+export interface DiscoverResponse {
+  company: DiscoveredCompany;
+  offices: DiscoveredOffice[];
+  photo?: DiscoveredPhoto;
+  /** Present only on soft failures so the client can show a tailored message. */
+  error?: "NOT_FOUND" | "LLM_INVALID" | "NO_OFFICES";
+}


### PR DESCRIPTION
🎯 **What:** This task addressed the missing unit tests for the `sanitizeOffices` function in the API discovery pipeline.

📊 **Coverage:**
- Valid office data sanitization.
- Handling of missing mandatory fields (city, country).
- Normalization (trimming whitespace, uppercase country codes).
- Validation against allowed sets for regions and office types.
- Deduplication logic based on city and country/countryCode.
- Handling of malformed numeric fields (latitude, longitude).
- Filtering of non-object entries in the input array.

✨ **Result:** Significant improvement in code reliability for the discovery pipeline. The `sanitizeOffices` function is now decoupled from the OpenRouter client for better modularity and testability.

---
*PR created automatically by Jules for task [15054623602405786443](https://jules.google.com/task/15054623602405786443) started by @lolzegarek*