### PR TITLE
🧪 [testing improvement] add unit tests for sanitizeOffices

### DIFF
--- a/__tests__/api/_lib/sanitizer.test.ts
+++ b/__tests__/api/_lib/sanitizer.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeOffices } from "../../../api/_lib/sanitizer";
+import type { DiscoveredOffice } from "../../../api/_lib/types";
+
+describe("sanitizeOffices", () => {
+  it("should return an empty array for an empty input array", () => {
+    expect(sanitizeOffices([])).toEqual([]);
+  });
+
+  it("should filter out non-object entries", () => {
+    const input = [null, undefined, 42, "string", []];
+    expect(sanitizeOffices(input as unknown as unknown[])).toEqual([]);
+  });
+
+  it("should correctly sanitize a valid office object", () => {
+    const input = [
+      {
+        country: "Ireland ",
+        countryCode: "ie",
+        region: " Europe",
+        city: "Dublin",
+        address: "70 Sir John Rogerson's Quay",
+        officeType: "hq",
+        latitude: 53.3448,
+        longitude: -6.236,
+        contactUrl: " https://google.com ",
+      },
+    ];
+    const expected: DiscoveredOffice[] = [
+      {
+        country: "Ireland",
+        countryCode: "IE",
+        region: "Europe",
+        city: "Dublin",
+        address: "70 Sir John Rogerson's Quay",
+        officeType: "hq",
+        latitude: 53.3448,
+        longitude: -6.236,
+        contactUrl: "https://google.com",
+      },
+    ];
+    expect(sanitizeOffices(input as unknown as unknown[])).toEqual(expected);
+  });
+
+  it("should skip entries missing mandatory fields (country, city)", () => {
+    const input = [
+      { country: "Ireland" }, // Missing city
+      { city: "Dublin" }, // Missing country
+      { country: "Ireland", city: "Dublin", address: "St" }, // Valid
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result).toHaveLength(1);
+    expect(result[0].city).toBe("Dublin");
+  });
+
+  it("should default officeType to 'branch' if missing or invalid", () => {
+    const input = [
+      { country: "A", city: "B" }, // Missing officeType
+      { country: "C", city: "D", officeType: "invalid" },
+      { country: "E", city: "F", officeType: "regional" },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].officeType).toBe("branch");
+    expect(result[1].officeType).toBe("branch");
+    expect(result[2].officeType).toBe("regional");
+  });
+
+  it("should deduplicate offices based on country, city, and address", () => {
+    const input = [
+      { country: "Ireland", city: "Dublin", address: "Street 1" },
+      { country: "ireland", city: "DUBLIN", address: " STREET 1 " }, // Duplicate
+      { country: "Ireland", city: "Dublin", address: "Street 2" }, // Unique
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result).toHaveLength(2);
+    expect(result[0].address).toBe("Street 1");
+    expect(result[1].address).toBe("Street 2");
+  });
+
+  it("should handle malformed or missing numeric fields (latitude, longitude)", () => {
+    const input = [
+      {
+        country: "A",
+        city: "B",
+        latitude: "not a number",
+        longitude: NaN,
+      },
+      {
+        country: "C",
+        city: "D",
+        latitude: Infinity,
+        longitude: 0,
+      },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0].latitude).toBeUndefined();
+    expect(result[0].longitude).toBeUndefined();
+    expect(result[1].latitude).toBeUndefined();
+    expect(result[1].longitude).toBe(0);
+  });
+
+  it("should trim all string fields", () => {
+    const input = [
+      {
+        country: " Ireland ",
+        countryCode: " IE ",
+        region: " Europe ",
+        city: " Dublin ",
+        address: " Street ",
+        postalCode: " 123 ",
+        contactUrl: " http://url.com ",
+      },
+    ];
+    const result = sanitizeOffices(input as unknown as unknown[]);
+    expect(result[0]).toEqual({
+      country: "Ireland",
+      countryCode: "IE",
+      region: "Europe",
+      city: "Dublin",
+      address: "Street",
+      postalCode: "123",
+      officeType: "branch",
+      contactUrl: "http://url.com",
+    });
+  });
+});

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenRouter client (OpenAI-compatible) + the two LLM calls discovery needs:
+ *   1. selectEntity   — pick the right Wikidata Q-id from search candidates.
+ *   2. structureOffices — turn raw SPARQL location rows into clean offices.
+ *
+ * The API key lives ONLY in server env (OPENROUTER_API_KEY) and never reaches
+ * the browser bundle. Model is swappable via OPENROUTER_MODEL.
+ */
+
+import OpenAI from "openai";
+import type { EntityCandidate, RawOfficeRow } from "../../scripts/lib/wikidata.mjs";
+import type { DiscoveredOffice } from "./types";
+import { sanitizeOffices } from "./sanitizer";
+
+let cached: OpenAI | null = null;
+
+export function getClient(): OpenAI {
+  if (cached) return cached;
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not configured");
+  cached = new OpenAI({
+    apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer":
+        process.env.OPENROUTER_REFERRER ?? "https://globalofficefinder.local",
+      "X-Title": "GlobalOfficeFinder",
+    },
+  });
+  return cached;
+}
+
+export function getModel(): string {
+  return process.env.OPENROUTER_MODEL ?? "anthropic/claude-3.5-sonnet";
+}
+
+/** Strip ```json fences and parse, tolerating minor LLM formatting slips. */
+function parseJsonLoose(content: string): unknown {
+  let text = content.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  return JSON.parse(text);
+}
+
+/**
+ * Ask the LLM which candidate entity is the actual business named `companyName`.
+ * Returns the chosen Q-id, or null if none of the candidates fit.
+ */
+export async function selectEntity(
+  companyName: string,
+  candidates: EntityCandidate[],
+): Promise<{ wikidataId: string | null; confidence?: number }> {
+  if (candidates.length === 0) return { wikidataId: null };
+  const client = getClient();
+  const list = candidates
+    .map((c) => `- ${c.id}: ${c.label}${c.description ? ` — ${c.description}` : ""}`)
+    .join("\n");
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You match a free-text company name to exactly one Wikidata entity. " +
+          "Choose the entity that is the operating business/company (not a person, " +
+          "film, product, place, or disambiguation page). Respond ONLY with JSON: " +
+          '{"wikidataId": "Q...", "confidence": 0-1} or {"wikidataId": null}.',
+      },
+      {
+        role: "user",
+        content: `Company name: "${companyName}"\nCandidates:\n${list}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as {
+      wikidataId?: string | null;
+      confidence?: number;
+    };
+    const id = parsed?.wikidataId;
+    if (typeof id === "string" && /^Q\d+$/.test(id)) {
+      return { wikidataId: id, confidence: parsed.confidence };
+    }
+    return { wikidataId: null };
+  } catch {
+    return { wikidataId: null };
+  }
+}
+
+/**
+ * Turn raw SPARQL location rows into a clean, de-duplicated list of offices
+ * matching DiscoveredOffice. The LLM normalises city/country, drops junk and
+ * classifies officeType; we still validate every field server-side.
+ */
+export async function structureOffices(
+  companyName: string,
+  rows: RawOfficeRow[],
+): Promise<DiscoveredOffice[] | null> {
+  if (rows.length === 0) return [];
+  const client = getClient();
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You return JSON of the form {\"offices\": Office[]} where Office is the " +
+          "TypeScript type {country: string, countryCode: string (ISO 3166-1 alpha-2), " +
+          "region: 'Americas'|'Europe'|'Asia-Pacific'|'Middle East & Africa', " +
+          "city: string, address?: string, officeType: 'hq'|'regional'|'branch', " +
+          "latitude?: number, longitude?: number}. Deduplicate locations. Skip any " +
+          "location missing at least a city and a country. Use the headquarters " +
+          "relation to mark exactly the main 'hq'. Preserve latitude/longitude when " +
+          "provided. Return ONLY the JSON object.",
+      },
+      {
+        role: "user",
+        content: `Company: "${companyName}"\nRaw locations (JSON):\n${JSON.stringify(
+          rows,
+          null,
+          0,
+        )}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as { offices?: unknown };
+    const arr = Array.isArray(parsed?.offices) ? parsed.offices : null;
+    if (!arr) return null;
+    return sanitizeOffices(arr);
+  } catch {
+    return null;
+  }
+}

--- a/api/_lib/sanitizer.ts
+++ b/api/_lib/sanitizer.ts
@@ -1,0 +1,48 @@
+import type { DiscoveredOffice } from "./types";
+
+/** Server-side validation — never trust the LLM output shape blindly. */
+export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
+  const out: DiscoveredOffice[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object" || raw === null) continue;
+    const o = raw as Record<string, unknown>;
+
+    const country = typeof o.country === "string" ? o.country.trim() : "";
+    const countryCode = typeof o.countryCode === "string" ? o.countryCode.trim().toUpperCase() : "";
+    const region = typeof o.region === "string" ? o.region.trim() : "";
+    const city = typeof o.city === "string" ? o.city.trim() : "";
+    const address = typeof o.address === "string" ? o.address.trim() : "";
+    const postalCode = typeof o.postalCode === "string" ? o.postalCode.trim() : "";
+
+    let officeType: "hq" | "regional" | "branch" = "branch";
+    if (typeof o.officeType === "string") {
+      const t = o.officeType.trim().toLowerCase();
+      if (t === "hq") officeType = "hq";
+      else if (t === "regional") officeType = "regional";
+    }
+
+    if (!country || !city) continue;
+
+    const key = `${country}-${city}-${address}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const office: DiscoveredOffice = {
+      country,
+      countryCode,
+      region,
+      city,
+      officeType,
+    };
+
+    if (address) office.address = address;
+    if (postalCode) office.postalCode = postalCode;
+    if (typeof o.latitude === "number" && Number.isFinite(o.latitude)) office.latitude = o.latitude;
+    if (typeof o.longitude === "number" && Number.isFinite(o.longitude)) office.longitude = o.longitude;
+    if (typeof o.contactUrl === "string") office.contactUrl = o.contactUrl.trim();
+
+    out.push(office);
+  }
+  return out;
+}

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for the runtime discovery endpoint. These intentionally mirror
+ * the client types in src/types/index.ts, but the API returns offices WITHOUT
+ * `id` / `companyId` — the client mints `temp-<uuid>` ids on receipt so the
+ * results never collide with the curated catalogue.
+ */
+
+export interface DiscoveredPhoto {
+  url: string;
+  sourceUrl: string;
+  author: string;
+  license: string;
+  licenseUrl: string;
+  title?: string;
+}
+
+export interface DiscoveredOffice {
+  country: string;
+  countryCode: string;
+  region: string;
+  city: string;
+  address?: string;
+  postalCode?: string;
+  officeType: "hq" | "regional" | "branch";
+  latitude?: number;
+  longitude?: number;
+  contactUrl?: string;
+}
+
+export interface DiscoveredCompany {
+  name: string;
+  description: string;
+  website?: string;
+  wikidataId?: string;
+}
+
+export interface DiscoverResponse {
+  company: DiscoveredCompany;
+  offices: DiscoveredOffice[];
+  photo?: DiscoveredPhoto;
+  /** Present only on soft failures so the client can show a tailored message. */
+  error?: "NOT_FOUND" | "LLM_INVALID" | "NO_OFFICES";
+}


### PR DESCRIPTION
Implemented a comprehensive suite of unit tests for the `sanitizeOffices` function. 
The function was extracted into its own module `api/_lib/sanitizer.ts` to facilitate isolated testing.
Tests cover:
- Empty and invalid inputs
- Mandatory field validation (country, city)
- Office type normalization and defaulting
- Deduplication of office entries
- Whitespace trimming across all string fields
- Handling of malformed latitude/longitude coordinates (NaN, Infinity)

All tests passed and ESLint checks are clean.

---
*PR created automatically by Jules for task [12363720400324289421](https://jules.google.com/task/12363720400324289421) started by @lolzegarek*