### PR TITLE
🧪 [testing improvement] add unit tests for sanitizeOffices

### DIFF
--- a/__tests__/api/_lib/sanitizer.test.ts
+++ b/__tests__/api/_lib/sanitizer.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeOffices } from "../../../api/_lib/sanitizer";
+
+describe("sanitizeOffices", () => {
+  it("returns an empty array when input is empty", () => {
+    expect(sanitizeOffices([])).toEqual([]);
+  });
+
+  it("skips non-object elements", () => {
+    const input = [null, undefined, 123, "string", []] as unknown as unknown[];
+    expect(sanitizeOffices(input)).toEqual([]);
+  });
+
+  it("sanitizes a valid office object", () => {
+    const input = [
+      {
+        country: " Poland ",
+        countryCode: "pl",
+        region: "Europe",
+        city: " Warsaw ",
+        address: " Aleje Jerozolimskie ",
+        officeType: "hq",
+        latitude: 52.2297,
+        longitude: 21.0122,
+      },
+    ];
+    const result = sanitizeOffices(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      country: "Poland",
+      countryCode: "PL",
+      region: "Europe",
+      city: "Warsaw",
+      address: "Aleje Jerozolimskie",
+      officeType: "hq",
+      latitude: 52.2297,
+      longitude: 21.0122,
+    });
+  });
+
+  it("skips objects missing country or city", () => {
+    const input = [
+      { city: "Warsaw" }, // missing country
+      { country: "Poland" }, // missing city
+      { country: " ", city: "Warsaw" }, // empty country
+      { country: "Poland", city: "" }, // empty city
+    ];
+    expect(sanitizeOffices(input)).toEqual([]);
+  });
+
+  it("defaults officeType to 'branch' if invalid or missing", () => {
+    const input = [
+      { country: "Poland", city: "Warsaw", officeType: "invalid" },
+      { country: "USA", city: "New York" },
+    ];
+    const result = sanitizeOffices(input);
+    expect(result[0].officeType).toBe("branch");
+    expect(result[1].officeType).toBe("branch");
+  });
+
+  it("handles missing optional fields", () => {
+    const input = [
+      {
+        country: "Poland",
+        city: "Warsaw",
+      },
+    ];
+    const result = sanitizeOffices(input);
+    expect(result[0]).toEqual({
+      country: "Poland",
+      countryCode: "",
+      region: "",
+      city: "Warsaw",
+      address: undefined,
+      officeType: "branch",
+      latitude: undefined,
+      longitude: undefined,
+    });
+  });
+
+  it("resets region if not in the allowed list", () => {
+    const input = [
+      {
+        country: "Poland",
+        city: "Warsaw",
+        region: "EMEA", // Not in ALLOWED_REGIONS
+      },
+    ];
+    const result = sanitizeOffices(input);
+    expect(result[0].region).toBe("");
+  });
+
+  it("validates and normalizes countryCode", () => {
+    const input = [
+      { country: "Poland", city: "Warsaw", countryCode: "pl" },
+      { country: "USA", city: "New York", countryCode: "USA" }, // Invalid (3 chars)
+      { country: "Germany", city: "Berlin", countryCode: "12" }, // Invalid (numbers)
+    ];
+    const result = sanitizeOffices(input);
+    expect(result[0].countryCode).toBe("PL");
+    expect(result[1].countryCode).toBe("");
+    expect(result[2].countryCode).toBe("");
+  });
+
+  it("deduplicates offices by city and country/countryCode", () => {
+    const input = [
+      { country: "Poland", city: "Warsaw", countryCode: "PL" },
+      { country: "Poland", city: "Warsaw", countryCode: "pl" }, // Duplicate
+      { country: "Poland", city: "Warsaw" }, // Duplicate (will have empty countryCode, but same country)
+      { country: "poland", city: "warsaw" }, // Duplicate (case insensitive)
+      { country: "USA", city: "Warsaw" }, // Different country
+      { country: "Poland", city: "Krakow" }, // Different city
+    ];
+    const result = sanitizeOffices(input);
+    // 1: Warsaw/PL
+    // 2: Warsaw/poland (because countryCode is empty in the 3rd and 4th items, key becomes warsaw|poland)
+    // 3: Warsaw/USA
+    // 4: Krakow/poland
+    expect(result).toHaveLength(4);
+    expect(result[0].city).toBe("Warsaw");
+    expect(result[0].countryCode).toBe("PL");
+    expect(result[1].city).toBe("Warsaw");
+    expect(result[1].country).toBe("Poland");
+    expect(result[1].countryCode).toBe("");
+    expect(result[2].country).toBe("USA");
+    expect(result[3].city).toBe("Krakow");
+  });
+});

--- a/api/_lib/openrouter.ts
+++ b/api/_lib/openrouter.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenRouter client (OpenAI-compatible) + the two LLM calls discovery needs:
+ *   1. selectEntity   — pick the right Wikidata Q-id from search candidates.
+ *   2. structureOffices — turn raw SPARQL location rows into clean offices.
+ *
+ * The API key lives ONLY in server env (OPENROUTER_API_KEY) and never reaches
+ * the browser bundle. Model is swappable via OPENROUTER_MODEL.
+ */
+
+import OpenAI from "openai";
+import type { EntityCandidate, RawOfficeRow } from "../../scripts/lib/wikidata.mjs";
+import type { DiscoveredOffice } from "./types";
+import { sanitizeOffices } from "./sanitizer";
+
+let cached: OpenAI | null = null;
+
+export function getClient(): OpenAI {
+  if (cached) return cached;
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not configured");
+  cached = new OpenAI({
+    apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer":
+        process.env.OPENROUTER_REFERRER ?? "https://globalofficefinder.local",
+      "X-Title": "GlobalOfficeFinder",
+    },
+  });
+  return cached;
+}
+
+export function getModel(): string {
+  return process.env.OPENROUTER_MODEL ?? "anthropic/claude-3.5-sonnet";
+}
+
+/** Strip ```json fences and parse, tolerating minor LLM formatting slips. */
+function parseJsonLoose(content: string): unknown {
+  let text = content.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  return JSON.parse(text);
+}
+
+/**
+ * Ask the LLM which candidate entity is the actual business named `companyName`.
+ * Returns the chosen Q-id, or null if none of the candidates fit.
+ */
+export async function selectEntity(
+  companyName: string,
+  candidates: EntityCandidate[],
+): Promise<{ wikidataId: string | null; confidence?: number }> {
+  if (candidates.length === 0) return { wikidataId: null };
+  const client = getClient();
+  const list = candidates
+    .map((c) => `- ${c.id}: ${c.label}${c.description ? ` — ${c.description}` : ""}`)
+    .join("\n");
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You match a free-text company name to exactly one Wikidata entity. " +
+          "Choose the entity that is the operating business/company (not a person, " +
+          "film, product, place, or disambiguation page). Respond ONLY with JSON: " +
+          '{"wikidataId": "Q...", "confidence": 0-1} or {"wikidataId": null}.',
+      },
+      {
+        role: "user",
+        content: `Company name: "${companyName}"\nCandidates:\n${list}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as {
+      wikidataId?: string | null;
+      confidence?: number;
+    };
+    const id = parsed?.wikidataId;
+    if (typeof id === "string" && /^Q\d+$/.test(id)) {
+      return { wikidataId: id, confidence: parsed.confidence };
+    }
+    return { wikidataId: null };
+  } catch {
+    return { wikidataId: null };
+  }
+}
+
+/**
+ * Turn raw SPARQL location rows into a clean, de-duplicated list of offices
+ * matching DiscoveredOffice. The LLM normalises city/country, drops junk and
+ * classifies officeType; we still validate every field server-side.
+ */
+export async function structureOffices(
+  companyName: string,
+  rows: RawOfficeRow[],
+): Promise<DiscoveredOffice[] | null> {
+  if (rows.length === 0) return [];
+  const client = getClient();
+
+  const completion = await client.chat.completions.create({
+    model: getModel(),
+    temperature: 0,
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You return JSON of the form {\"offices\": Office[]} where Office is the " +
+          "TypeScript type {country: string, countryCode: string (ISO 3166-1 alpha-2), " +
+          "region: 'Americas'|'Europe'|'Asia-Pacific'|'Middle East & Africa', " +
+          "city: string, address?: string, officeType: 'hq'|'regional'|'branch', " +
+          "latitude?: number, longitude?: number}. Deduplicate locations. Skip any " +
+          "location missing at least a city and a country. Use the headquarters " +
+          "relation to mark exactly the main 'hq'. Preserve latitude/longitude when " +
+          "provided. Return ONLY the JSON object.",
+      },
+      {
+        role: "user",
+        content: `Company: "${companyName}"\nRaw locations (JSON):\n${JSON.stringify(
+          rows,
+          null,
+          0,
+        )}`,
+      },
+    ],
+  });
+
+  const content = completion.choices[0]?.message?.content ?? "";
+  try {
+    const parsed = parseJsonLoose(content) as { offices?: unknown };
+    const arr = Array.isArray(parsed?.offices) ? parsed.offices : null;
+    if (!arr) return null;
+    return sanitizeOffices(arr);
+  } catch {
+    return null;
+  }
+}

--- a/api/_lib/sanitizer.ts
+++ b/api/_lib/sanitizer.ts
@@ -1,0 +1,55 @@
+import type { DiscoveredOffice } from "./types";
+
+export const OFFICE_TYPES = new Set(["hq", "regional", "branch"]);
+export const ALLOWED_REGIONS = new Set([
+  "Americas",
+  "Europe",
+  "Asia-Pacific",
+  "Middle East & Africa",
+]);
+
+/** Server-side validation — never trust the LLM output shape blindly. */
+export function sanitizeOffices(arr: unknown[]): DiscoveredOffice[] {
+  const out: DiscoveredOffice[] = [];
+  const seen = new Set<string>();
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object") continue;
+    const o = raw as Record<string, unknown>;
+    const country = typeof o.country === "string" ? o.country.trim() : "";
+    const city = typeof o.city === "string" ? o.city.trim() : "";
+    if (!country || !city) continue;
+
+    const countryCode =
+      typeof o.countryCode === "string" && /^[A-Za-z]{2}$/.test(o.countryCode)
+        ? o.countryCode.toUpperCase()
+        : "";
+    // Drop off-list values (e.g. "EMEA", "APAC") so fillRegion() in the
+    // handler can derive a canonical region from the country code instead.
+    const rawRegion = typeof o.region === "string" ? o.region.trim() : "";
+    const region = ALLOWED_REGIONS.has(rawRegion) ? rawRegion : "";
+    const officeType =
+      typeof o.officeType === "string" && OFFICE_TYPES.has(o.officeType)
+        ? (o.officeType as DiscoveredOffice["officeType"])
+        : "branch";
+    const address =
+      typeof o.address === "string" && o.address.trim() ? o.address.trim() : undefined;
+    const latitude = typeof o.latitude === "number" ? o.latitude : undefined;
+    const longitude = typeof o.longitude === "number" ? o.longitude : undefined;
+
+    const key = `${city.toLowerCase()}|${countryCode || country.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    out.push({
+      country,
+      countryCode,
+      region,
+      city,
+      address,
+      officeType,
+      latitude,
+      longitude,
+    });
+  }
+  return out;
+}

--- a/api/_lib/types.ts
+++ b/api/_lib/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for the runtime discovery endpoint. These intentionally mirror
+ * the client types in src/types/index.ts, but the API returns offices WITHOUT
+ * `id` / `companyId` — the client mints `temp-<uuid>` ids on receipt so the
+ * results never collide with the curated catalogue.
+ */
+
+export interface DiscoveredPhoto {
+  url: string;
+  sourceUrl: string;
+  author: string;
+  license: string;
+  licenseUrl: string;
+  title?: string;
+}
+
+export interface DiscoveredOffice {
+  country: string;
+  countryCode: string;
+  region: string;
+  city: string;
+  address?: string;
+  officeType: "hq" | "regional" | "branch";
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface DiscoveredCompany {
+  name: string;
+  description: string;
+  website?: string;
+  wikidataId?: string;
+}
+
+export interface DiscoverResponse {
+  company: DiscoveredCompany;
+  offices: DiscoveredOffice[];
+  photo?: DiscoveredPhoto;
+  /** Present only on soft failures so the client can show a tailored message. */
+  error?: "NOT_FOUND" | "LLM_INVALID" | "NO_OFFICES";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2638,16 +2638,6 @@
         "devtools-protocol": "*"
       }
     },
-    "node_modules/chromium-bidi/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4128,9 +4118,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7785,9 +7775,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {


### PR DESCRIPTION
- 🎯 **What:** Added comprehensive unit tests for the `sanitizeOffices` function to ensure robust validation and de-duplication of LLM-generated office data.
- 📊 **Coverage:** Tested scenarios including valid inputs, empty/malformed inputs, missing required fields (city/country), string normalization (trimming, casing), region/type validation, and deduplication logic.
- ✨ **Result:** Increased reliability of the office discovery pipeline by verifying the data sanitization layer in isolation. The function was refactored into a separate module (`api/_lib/sanitizer.ts`) to enable testing without external dependencies.

---
*PR created automatically by Jules for task [2546378414009437843](https://jules.google.com/task/2546378414009437843) started by @lolzegarek*