### PR TITLE
ci: przepnij runnery na self-hosted

### DIFF
--- a/.github/workflows/ci-scraper-gate.yml
+++ b/.github/workflows/ci-scraper-gate.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   scraper-gate:
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-scraper-gate.yml
+++ b/.github/workflows/ci-scraper-gate.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   scraper-gate:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   security:
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v7
       - name: Setup Node

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   security:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
       - name: Setup Node

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   validate-data:
     name: Validate data files
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -51,7 +51,7 @@ jobs:
   test:
     name: Run tests
     needs: validate-data
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -69,7 +69,7 @@ jobs:
   build:
     name: Build site
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -101,7 +101,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Playwright E2E & Lighthouse
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Playwright E2E & Lighthouse
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/full-secret-scan.yml
+++ b/.github/workflows/full-secret-scan.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   secret-scan:
     name: Full History Gitleaks Scan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   validate-data:
     name: Validate data files
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v7
 
@@ -44,7 +44,7 @@ jobs:
 
   lint-and-build:
     name: Lint, Test & Build
-    runs-on: self-hosted
+    runs-on: "${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   validate-data:
     name: Validate data files
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 
@@ -44,7 +44,7 @@ jobs:
 
   lint-and-build:
     name: Lint, Test & Build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/scraper-discovery.yml
+++ b/.github/workflows/scraper-discovery.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   discover-and-pr:
     name: Discover companies and open PR
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       SCRAPER_BOT_TOKEN: ${{ secrets.SCRAPER_BOT_TOKEN }}
     steps:

--- a/.github/workflows/scraper-staging.yml
+++ b/.github/workflows/scraper-staging.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   run-scraper:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/verify-offices.yml
+++ b/.github/workflows/verify-offices.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   verify-and-pr:
     name: Batch-verify offices and open PR
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Zmienia `runs-on: ubuntu-latest` -> `self-hosted` we wszystkich workflowach, aby CI trafialo na self-hostowane runnery organizacji (arm64).

Generated with Claude Code