### PR TITLE
⚡ Optimize search filter performance by pre-computing search strings

### DIFF
--- a/scripts/benchmark_search.mjs
+++ b/scripts/benchmark_search.mjs
@@ -1,0 +1,65 @@
+import { readFileSync } from 'fs';
+
+const companies = JSON.parse(readFileSync('./data/companies.json', 'utf8'));
+const offices = JSON.parse(readFileSync('./data/offices.json', 'utf8'));
+
+const companyById = {};
+for (const c of companies) companyById[c.id] = c;
+
+const needles = ['london', 'tech', 'san francisco', 'software', 'paris', 'unknown'];
+
+function baseline() {
+    const start = performance.now();
+    for (let i = 0; i < 1000; i++) {
+        for (const needle of needles) {
+            offices.filter(o => {
+                const co = companyById[o.companyId];
+                if (!co) return false;
+                const s = (
+                    co.name +
+                    " " +
+                    co.industry +
+                    " " +
+                    o.city +
+                    " " +
+                    o.country
+                ).toLowerCase();
+                return s.includes(needle);
+            });
+        }
+    }
+    const end = performance.now();
+    return end - start;
+}
+
+const enrichedOffices = offices.map(o => {
+    const co = companyById[o.companyId];
+    if (!co) return { ...o, searchText: '' };
+    const searchText = (
+        co.name +
+        " " +
+        co.industry +
+        " " +
+        o.city +
+        " " +
+        o.country
+    ).toLowerCase();
+    return { ...o, searchText };
+});
+
+function optimized() {
+    const start = performance.now();
+    for (let i = 0; i < 1000; i++) {
+        for (const needle of needles) {
+            enrichedOffices.filter(o => o.searchText.includes(needle));
+        }
+    }
+    const end = performance.now();
+    return end - start;
+}
+
+const b = baseline();
+console.log(`Baseline: ${b.toFixed(2)}ms`);
+const o = optimized();
+console.log(`Optimized: ${o.toFixed(2)}ms`);
+console.log(`Improvement: ${((b - o) / b * 100).toFixed(2)}%`);

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -4,14 +4,19 @@ import type { Company, Office } from "../types";
 import { typeTag } from "../utils/typeTag";
 
 const COMPANIES = companiesJson as Company[];
-const OFFICES = (officesJson as unknown[]).map((o) => {
-  const office = o as Office;
-  const tag = typeTag(office.officeType);
-  return { ...office, tag, tone: tag.tone };
-}) as Office[];
 
 const COMPANY_BY_ID: Record<string, Company> = {};
 for (const c of COMPANIES) COMPANY_BY_ID[c.id] = c;
+
+const OFFICES = (officesJson as unknown[]).map((o) => {
+  const office = o as Office;
+  const co = COMPANY_BY_ID[office.companyId];
+  const tag = typeTag(office.officeType);
+  const searchText = co
+    ? `${co.name} ${co.industry} ${office.city} ${office.country}`.toLowerCase()
+    : "";
+  return { ...office, tag, tone: tag.tone, searchText };
+}) as Office[];
 
 const PUBLIC_OFFICES = OFFICES.filter(
   (o) => o.verification?.verdict !== "rejected",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -87,16 +87,7 @@ export default function HomePage() {
       if (otype && o.tone !== otype) return false;
       if (industry && co.industry !== industry) return false;
       if (needle) {
-        const s = (
-          co.name +
-          " " +
-          co.industry +
-          " " +
-          o.city +
-          " " +
-          o.country
-        ).toLowerCase();
-        if (!s.includes(needle)) return false;
+        if (!o.searchText?.includes(needle)) return false;
       }
       return true;
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,4 +55,6 @@ export interface Office {
   longitude?: number;
   contactUrl?: string;
   verification?: OfficeVerification;
+  /** Pre-computed search text for filtering. */
+  searchText?: string;
 }


### PR DESCRIPTION
### 💡 **What:** 
Optimized the search filtering logic in the `HomePage` component. Instead of concatenating and lowercasing multiple fields (`company name`, `industry`, `city`, `country`) on every filter iteration, a pre-computed `searchText` property is now added to each `Office` object during the initial data enrichment phase in the `useData` hook.

### 🎯 **Why:** 
The previous implementation performed expensive string operations inside a high-frequency filter loop (triggered on every keystroke). With approximately 154 offices, this led to unnecessary CPU cycles and allocations, especially noticeable on lower-end devices or during rapid typing.

### 📊 **Measured Improvement:**
Using a custom benchmark script (`scripts/benchmark_search.mjs`) that simulated 1,000 filtering iterations:
- **Baseline:** 358.82ms
- **Optimized:** 71.17ms
- **Improvement:** **~80.17% reduction in execution time.**

Verified correctness via unit tests, linting, and Playwright end-to-end verification.

---
*PR created automatically by Jules for task [4709338074743408901](https://jules.google.com/task/4709338074743408901) started by @lolzegarek*