### PR TITLE
🧹 remove non-null assertions in AboutPhotosPage

### DIFF
--- a/src/pages/AboutPhotosPage.tsx
+++ b/src/pages/AboutPhotosPage.tsx
@@ -83,21 +83,23 @@ export default function AboutPhotosPage() {
         </h2>
         <ul className="gof-about-table">
           {credited.map((c) => {
-            const src = sanitizeUrl(c.photo!.sourceUrl);
-            const lic = sanitizeUrl(c.photo!.licenseUrl);
+            const photo = c.photo;
+            if (!photo) return null;
+            const src = sanitizeUrl(photo.sourceUrl);
+            const lic = sanitizeUrl(photo.licenseUrl);
             return (
               <li key={c.id}>
                 <Link to={`/company/${encodeURIComponent(c.id)}`} className="gof-about-co">
                   {c.name}
                 </Link>
                 <span className="gof-about-meta">
-                  {c.photo!.author} ·{" "}
+                  {photo.author} ·{" "}
                   {lic ? (
                     <a href={lic} target="_blank" rel="noopener noreferrer">
-                      {c.photo!.license}
+                      {photo.license}
                     </a>
                   ) : (
-                    c.photo!.license
+                    photo.license
                   )}
                   {src && (
                     <>


### PR DESCRIPTION
The `AboutPhotosPage.tsx` file used non-null assertions (`!`) when accessing the `photo` property of a company within a `map` callback. Although the companies were filtered to include only those with photos, using `!` is discouraged as it can lead to runtime crashes if the data structure changes or the filter logic is flawed.

This PR refactors the mapping logic to:
1. Extract `c.photo` into a local `photo` variable.
2. Add a safety check (`if (!photo) return null;`) to narrow the type.
3. Replace all 5 instances of `c.photo!` with the narrowed `photo` variable.

This change improves the maintainability and robustness of the codebase without altering the user-visible behavior.

Verification:
- Ran `npm test` and all 67 tests passed.
- Performed frontend verification using Playwright, capturing a screenshot and video of the "About the photos" page to ensure the credited photos list still renders correctly.
- Obtained a successful code review.

---
*PR created automatically by Jules for task [14034674238690009216](https://jules.google.com/task/14034674238690009216) started by @lolzegarek*