### PR TITLE
⚡ Optimize CountryPage office filtering complexity

### DIFF
--- a/scripts/benchmark_country_page.mjs
+++ b/scripts/benchmark_country_page.mjs
@@ -1,0 +1,50 @@
+import { readFileSync } from 'fs';
+import { performance } from 'perf_hooks';
+
+const offices = JSON.parse(readFileSync('./data/offices.json', 'utf8'));
+const companies = JSON.parse(readFileSync('./data/companies.json', 'utf8'));
+
+const countryCode = 'United States'; // Example country with many offices
+const countryOffices = offices.filter(o => o.country === countryCode);
+const uniqueCompanyIds = [...new Set(countryOffices.map(o => o.companyId))];
+
+function originalLogic() {
+    const results = [];
+    for (const cid of uniqueCompanyIds) {
+        const list = countryOffices.filter(o => o.companyId === cid);
+        results.push({ cid, count: list.length });
+    }
+    return results;
+}
+
+function optimizedLogic() {
+    const officesByCompany = Map.groupBy(countryOffices, o => o.companyId);
+    const results = [];
+    for (const cid of uniqueCompanyIds) {
+        const list = officesByCompany.get(cid) || [];
+        results.push({ cid, count: list.length });
+    }
+    return results;
+}
+
+// Warmup
+for (let i = 0; i < 100; i++) {
+    originalLogic();
+    optimizedLogic();
+}
+
+const iterations = 1000;
+
+let start = performance.now();
+for (let i = 0; i < iterations; i++) {
+    originalLogic();
+}
+let end = performance.now();
+console.log(`Original Logic: ${(end - start).toFixed(4)}ms total for ${iterations} iterations (${((end - start) / iterations).toFixed(4)}ms per iteration)`);
+
+start = performance.now();
+for (let i = 0; i < iterations; i++) {
+    optimizedLogic();
+}
+end = performance.now();
+console.log(`Optimized Logic: ${(end - start).toFixed(4)}ms total for ${iterations} iterations (${((end - start) / iterations).toFixed(4)}ms per iteration)`);

--- a/src/pages/CountryPage.tsx
+++ b/src/pages/CountryPage.tsx
@@ -37,6 +37,23 @@ export default function CountryPage() {
     [allOffices, code],
   );
 
+  const { companies, cities, officesByCompany } = useMemo(() => {
+    const companyIds = new Set<string>();
+    const cityNames = new Set<string>();
+    const grouped: Record<string, typeof offices> = {};
+    for (const o of offices) {
+      companyIds.add(o.companyId);
+      cityNames.add(o.city);
+      if (!grouped[o.companyId]) grouped[o.companyId] = [];
+      grouped[o.companyId].push(o);
+    }
+    return {
+      companies: Array.from(companyIds),
+      cities: cityNames,
+      officesByCompany: grouped,
+    };
+  }, [offices]);
+
   if (!offices.length) {
     return (
       <div className="gof-notfound">
@@ -50,8 +67,6 @@ export default function CountryPage() {
 
   const countryCode = offices[0].countryCode;
   const region = offices[0].region;
-  const companies = [...new Set(offices.map((o) => o.companyId))];
-  const cities = new Set(offices.map((o) => o.city));
 
   function selectOffice(officeId: string) {
     setActiveId(officeId);
@@ -100,8 +115,8 @@ export default function CountryPage() {
             </h2>
             {companies.map((cid) => {
               const co = companyById[cid];
-              if (!co) return null;
-              const list = offices.filter((o) => o.companyId === cid);
+              const list = officesByCompany[cid];
+              if (!co || !list) return null;
               return (
                 <div
                   key={cid}


### PR DESCRIPTION
💡 **What:** Refactored `src/pages/CountryPage.tsx` to pre-group offices by `companyId` using a dictionary inside a `useMemo` hook. Also consolidated unique companies and cities extraction into the same loop.

🎯 **Why:** The previous implementation had $O(N \cdot M)$ complexity, where $N$ is the number of companies in a country and $M$ is the number of offices. This caused redundant filtering inside the render loop.

📊 **Measured Improvement:**
- Baseline logic execution: ~0.0467ms
- Optimized logic execution: ~0.0106ms
- Speedup: **~4.4x** (~77% reduction in execution time for the data processing logic).

Verification:
- `npm run lint`: Passed
- `npm run test:ci:unit`: Passed
- Visual verification: Confirmed via Playwright screenshot.

---
*PR created automatically by Jules for task [5802369557476630278](https://jules.google.com/task/5802369557476630278) started by @lolzegarek*