### PR TITLE
🧹 Extract inline styles from Dropdown component

### DIFF
--- a/__tests__/components/Dropdown.test.tsx
+++ b/__tests__/components/Dropdown.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import Dropdown from "../../src/components/Dropdown";
+
+describe("Dropdown", () => {
+  const options = [
+    { value: "a", label: "Option A" },
+    { value: "b", label: "Option B" },
+  ];
+  const onChange = vi.fn();
+
+  it("renders correctly with label", () => {
+    const { getByText } = render(
+      <Dropdown label="Test Dropdown" value="" options={options} onChange={onChange} />
+    );
+    expect(getByText("Test Dropdown")).toBeInTheDocument();
+  });
+
+  it("renders correctly with selected value", () => {
+    const { getByText } = render(
+      <Dropdown label="Test Dropdown" value="a" options={options} onChange={onChange} />
+    );
+    expect(getByText("Option A")).toBeInTheDocument();
+  });
+
+  it("applies the correct classes to label and chevron", () => {
+    const { container } = render(
+      <Dropdown label="Test Dropdown" value="" options={options} onChange={onChange} />
+    );
+
+    const labelSpan = container.querySelector(".gof-dd-label");
+    expect(labelSpan).toBeInTheDocument();
+    expect(labelSpan?.tagName.toLowerCase()).toBe("span");
+
+    const chevronSvg = container.querySelector(".gof-dd-chevron");
+    expect(chevronSvg).toBeInTheDocument();
+    expect(chevronSvg?.tagName.toLowerCase()).toBe("svg");
+  });
+
+  it("does not have inline opacity or margin styles on label and chevron", () => {
+    const { container } = render(
+      <Dropdown label="Test Dropdown" value="" options={options} onChange={onChange} />
+    );
+
+    const labelSpan = container.querySelector(".gof-dd-label") as HTMLElement;
+    expect(labelSpan.style.opacity).toBe("");
+
+    const chevronSvg = container.querySelector(".gof-dd-chevron") as HTMLElement;
+    expect(chevronSvg.style.marginLeft).toBe("");
+    expect(chevronSvg.style.opacity).toBe("");
+  });
+
+  it("applies is-active class to button when value is present", () => {
+    const { getByRole } = render(
+      <Dropdown label="Test Dropdown" value="a" options={options} onChange={onChange} />
+    );
+    const button = getByRole("button");
+    expect(button.className).toContain("is-active");
+  });
+});

--- a/src/App.css
+++ b/src/App.css
@@ -309,6 +309,16 @@ a {
   width: 100%;
   justify-content: space-between;
 }
+.gof-dd-label {
+  opacity: 0.7;
+}
+.gof-pill.is-active .gof-dd-label {
+  opacity: 1;
+}
+.gof-dd-chevron {
+  margin-left: 6px;
+  opacity: 0.6;
+}
 .gof-dd-menu {
   position: absolute;
   top: calc(100% + 6px);

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -47,12 +47,12 @@ export default function Dropdown({ label, value, options, onChange, width }: Dro
         aria-label={label}
         onClick={() => setOpen((o) => !o)}
       >
-        <span style={{ opacity: value ? 1 : 0.7 }}>{cur ? cur.label : label}</span>
+        <span className="gof-dd-label">{cur ? cur.label : label}</span>
         <svg
           width="12"
           height="12"
           viewBox="0 0 12 12"
-          style={{ marginLeft: 6, opacity: 0.6 }}
+          className="gof-dd-chevron"
           aria-hidden="true"
         >
           <path


### PR DESCRIPTION
🎯 **What:** Extracted inline styles from the `Dropdown` component's label and chevron into `src/App.css`.
💡 **Why:** Improves maintainability, readability, and separation of concerns by following the codebase's CSS patterns.
✅ **Verification:**
- Ran unit tests for the `Dropdown` component ensuring correct class application and removal of inline styles.
- Verified visual parity with a Playwright script and screenshot.
- Ran `npm run lint` and `npm run test:ci:unit`.
✨ **Result:** Cleaner JSX in `Dropdown.tsx` and centralized styling in `App.css`.

---
*PR created automatically by Jules for task [3886750837553623107](https://jules.google.com/task/3886750837553623107) started by @lolzegarek*