### PR TITLE
🧹 Extract inline styles in Photo component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -138,7 +138,13 @@ a {
   height: 100%;
   object-fit: cover;
   display: block;
-  transition: opacity 0.4s, transform 0.4s;
+  opacity: 0;
+  transition:
+    opacity 0.4s,
+    transform 0.4s;
+}
+.gof-photo img.is-loaded {
+  opacity: 1;
 }
 .gof-photo-grad {
   position: absolute;

--- a/src/components/Photo.tsx
+++ b/src/components/Photo.tsx
@@ -64,7 +64,7 @@ export default function Photo({
         loading="lazy"
         onLoad={() => setState("loaded")}
         onError={() => setState("error")}
-        style={{ opacity: state === "loaded" ? 1 : 0 }}
+        className={state === "loaded" ? "is-loaded" : ""}
       />
       <div className="gof-photo-grad" />
       {useReal && state !== "error" ? (


### PR DESCRIPTION
🎯 **What:** Extracted the inline `opacity` style from the `img` element in `src/components/Photo.tsx` into a CSS class in `src/App.css`.
💡 **Why:** This improves maintainability and readability by separating concerns and following the codebase's existing styling patterns.
✅ **Verification:**
- Ran `npm run test:ci:unit` (all 67 tests passed).
- Visual verification with Playwright confirmed the fade-in effect still works correctly using the `.is-loaded` class.
- Successfully passed code review.
✨ **Result:** Cleaned up the `Photo` component and standardized image loading styles.

---
*PR created automatically by Jules for task [5056967687275420006](https://jules.google.com/task/5056967687275420006) started by @lolzegarek*