### PR TITLE
🧹 refactor: extract inline styles from Dropdown component to CSS

### DIFF
--- a/__tests__/components/Dropdown.test.tsx
+++ b/__tests__/components/Dropdown.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import Dropdown from "../../src/components/Dropdown";
+
+const options = [
+  { value: "a", label: "Option A" },
+  { value: "b", label: "Option B", count: 5 },
+];
+
+describe("Dropdown", () => {
+  it("renders with label when no value is selected", () => {
+    render(
+      <Dropdown
+        label="Select something"
+        value=""
+        options={options}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByText("Select something")).toBeInTheDocument();
+  });
+
+  it("renders selected option label", () => {
+    render(
+      <Dropdown
+        label="Select something"
+        value="a"
+        options={options}
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+  });
+
+  it("toggles menu on click", () => {
+    render(
+      <Dropdown
+        label="Select something"
+        value=""
+        options={options}
+        onChange={() => {}}
+      />
+    );
+    const button = screen.getByRole("button", { name: "Select something" });
+    fireEvent.click(button);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByText("Option A")).toBeInTheDocument();
+    expect(screen.getByText("Option B")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange and closes menu when an option is clicked", () => {
+    const onChange = vi.fn();
+    render(
+      <Dropdown
+        label="Select something"
+        value=""
+        options={options}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Select something" }));
+    // The option text includes the count if present
+    fireEvent.click(screen.getByRole("option", { name: /Option B/ }));
+
+    expect(onChange).toHaveBeenCalledWith("b");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("closes menu on Escape key", () => {
+    render(
+      <Dropdown
+        label="Select something"
+        value=""
+        options={options}
+        onChange={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Select something" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("closes menu on click outside", () => {
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <Dropdown
+          label="Select something"
+          value=""
+          options={options}
+          onChange={() => {}}
+        />
+      </div>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Select something" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("applies width correctly for numeric values", () => {
+    const { container } = render(
+      <Dropdown
+        label="Test"
+        value=""
+        options={options}
+        onChange={() => {}}
+        width={300}
+      />
+    );
+    const element = container.firstChild as HTMLElement;
+    expect(element.style.getPropertyValue("--dd-width")).toBe("300px");
+  });
+
+  it("applies width correctly for string values", () => {
+    const { container } = render(
+      <Dropdown
+        label="Test"
+        value=""
+        options={options}
+        onChange={() => {}}
+        width="50%"
+      />
+    );
+    const element = container.firstChild as HTMLElement;
+    expect(element.style.getPropertyValue("--dd-width")).toBe("50%");
+  });
+});

--- a/src/App.css
+++ b/src/App.css
@@ -10,8 +10,12 @@
   --surface: #ffffff;
   --line: #e3e7f0;
   --line-strong: #d2d8e6;
-  --font-head: "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-body: "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-head:
+    "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  --font-body:
+    "Plus Jakarta Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
   --head-weight: 600;
   --head-tracking: -0.02em;
   --radius: 12px;
@@ -138,7 +142,9 @@ a {
   height: 100%;
   object-fit: cover;
   display: block;
-  transition: opacity 0.4s, transform 0.4s;
+  transition:
+    opacity 0.4s,
+    transform 0.4s;
 }
 .gof-photo-grad {
   position: absolute;
@@ -200,7 +206,9 @@ a {
   border: 1px solid var(--line);
   border-radius: calc(var(--radius) - 2px);
   outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 .gof-search:focus {
   border-color: var(--accent);
@@ -304,10 +312,21 @@ a {
 
 .gof-dd {
   position: relative;
+  width: var(--dd-width, auto);
 }
 .gof-dd .gof-pill {
   width: 100%;
   justify-content: space-between;
+}
+.gof-dd .gof-pill span {
+  opacity: 0.7;
+}
+.gof-dd .gof-pill.is-active span {
+  opacity: 1;
+}
+.gof-dd-chevron {
+  margin-left: 6px;
+  opacity: 0.6;
 }
 .gof-dd-menu {
   position: absolute;
@@ -369,7 +388,10 @@ a {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   overflow: hidden;
-  transition: transform 0.16s, box-shadow 0.16s, border-color 0.16s;
+  transition:
+    transform 0.16s,
+    box-shadow 0.16s,
+    border-color 0.16s;
   color: inherit;
 }
 .gof-card:hover {
@@ -598,7 +620,10 @@ a {
   border-radius: var(--radius);
   overflow: hidden;
   cursor: pointer;
-  transition: box-shadow 0.14s, border-color 0.14s, transform 0.14s;
+  transition:
+    box-shadow 0.14s,
+    border-color 0.14s,
+    transform 0.14s;
 }
 .gof-officecard:hover,
 .gof-officecard.is-hover {
@@ -607,7 +632,9 @@ a {
 }
 .gof-officecard.is-active {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1.5px var(--accent), 0 8px 22px rgba(15, 20, 50, 0.14);
+  box-shadow:
+    0 0 0 1.5px var(--accent),
+    0 8px 22px rgba(15, 20, 50, 0.14);
 }
 .gof-officecard:focus-visible {
   outline: 3px solid var(--accent-soft);
@@ -816,7 +843,11 @@ a {
   background: var(--accent);
   border: 3px solid #fff;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  transition: width 0.14s, height 0.14s, box-shadow 0.14s, transform 0.14s;
+  transition:
+    width 0.14s,
+    height 0.14s,
+    box-shadow 0.14s,
+    transform 0.14s;
   display: block;
 }
 .gof-pin.is-hover .gof-pin-dot {
@@ -826,7 +857,9 @@ a {
   width: 21px;
   height: 21px;
   border-width: 4px;
-  box-shadow: 0 0 0 6px var(--accent-soft), 0 3px 10px rgba(0, 0, 0, 0.35);
+  box-shadow:
+    0 0 0 6px var(--accent-soft),
+    0 3px 10px rgba(0, 0, 0, 0.35);
 }
 .gof-tip {
   font-family: var(--font-body);
@@ -1020,7 +1053,9 @@ a {
   opacity: 0;
   transform: translateY(4px);
   pointer-events: none;
-  transition: opacity 0.14s, transform 0.14s;
+  transition:
+    opacity 0.14s,
+    transform 0.14s;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -1160,7 +1195,10 @@ a {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.14s, color 0.14s, transform 0.14s;
+  transition:
+    background 0.14s,
+    color 0.14s,
+    transform 0.14s;
 }
 .gof-resetview:hover {
   color: var(--accent);
@@ -1354,7 +1392,9 @@ a {
   border-radius: 8px;
   padding: 7px 10px;
   outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   width: 100%;
 }
 

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -14,7 +14,13 @@ interface DropdownProps {
   width?: number | string;
 }
 
-export default function Dropdown({ label, value, options, onChange, width }: DropdownProps) {
+export default function Dropdown({
+  label,
+  value,
+  options,
+  onChange,
+  width,
+}: DropdownProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
   const listboxId = useId();
@@ -23,7 +29,8 @@ export default function Dropdown({ label, value, options, onChange, width }: Dro
   useEffect(() => {
     if (!open) return;
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") setOpen(false);
@@ -36,8 +43,12 @@ export default function Dropdown({ label, value, options, onChange, width }: Dro
     };
   }, [open]);
 
+  const style = {
+    "--dd-width": typeof width === "number" ? `${width}px` : width,
+  } as React.CSSProperties;
+
   return (
-    <div className="gof-dd" ref={ref} style={{ width }}>
+    <div className="gof-dd" ref={ref} style={style}>
       <button
         type="button"
         className={"gof-pill" + (value ? " is-active" : "")}
@@ -47,12 +58,12 @@ export default function Dropdown({ label, value, options, onChange, width }: Dro
         aria-label={label}
         onClick={() => setOpen((o) => !o)}
       >
-        <span style={{ opacity: value ? 1 : 0.7 }}>{cur ? cur.label : label}</span>
+        <span>{cur ? cur.label : label}</span>
         <svg
           width="12"
           height="12"
           viewBox="0 0 12 12"
-          style={{ marginLeft: 6, opacity: 0.6 }}
+          className="gof-dd-chevron"
           aria-hidden="true"
         >
           <path
@@ -77,14 +88,18 @@ export default function Dropdown({ label, value, options, onChange, width }: Dro
               type="button"
               role="option"
               aria-selected={o.value === value}
-              className={"gof-dd-item" + (o.value === value ? " is-active" : "")}
+              className={
+                "gof-dd-item" + (o.value === value ? " is-active" : "")
+              }
               onClick={() => {
                 onChange(o.value);
                 setOpen(false);
               }}
             >
               <span>{o.label}</span>
-              {o.count != null && <span className="gof-dd-count">{o.count}</span>}
+              {o.count != null && (
+                <span className="gof-dd-count">{o.count}</span>
+              )}
             </button>
           ))}
         </div>


### PR DESCRIPTION
### 🎯 What: The code health issue addressed
Extracted inline styles from `src/components/Dropdown.tsx` into `src/App.css`. Specifically:
- Moved dynamic `width` to a CSS variable `--dd-width`.
- Moved conditional `opacity` on the label span to CSS using the `.is-active` class.
- Moved `margin` and `opacity` on the chevron SVG to a new `.gof-dd-chevron` class.

### 💡 Why: How this improves maintainability
- **Separation of Concerns:** Keeps presentation logic in CSS files and component logic in TSX.
- **Consistency:** Makes it easier to update the look and feel of all dropdowns globally via CSS.
- **Readability:** Cleans up the JSX template, making it easier to follow the component structure.

### ✅ Verification: How you confirmed the change is safe
- **Unit Tests:** Created `__tests__/components/Dropdown.test.tsx` with 8 test cases covering rendering, interaction, and prop handling (including numeric vs. string width).
- **Regression Testing:** Ran the full unit test suite (73 tests passed).
- **Visual Verification:** Used a Playwright script to capture screenshots of the dropdown in various states (closed, open, selected) and confirmed visual parity with the original implementation.
- **Linting/Formatting:** Verified that `npm run lint` and `npm run format` pass (restricted to modified files).

### ✨ Result: The improvement achieved
A cleaner, more maintainable `Dropdown` component that adheres to the project's styling conventions without sacrificing dynamic functionality.

---
*PR created automatically by Jules for task [16689107796425447507](https://jules.google.com/task/16689107796425447507) started by @lolzegarek*